### PR TITLE
Refine EnvForge camera runtime contract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,8 +226,8 @@ deploy_api: build_api
 		--set-env-vars DB_ID=$(DB_ID),REGION=$(REGION),TRAINER_JOB_NAME=$(TRAINER_JOB_NAME),PROJECT_ID=$(PROJECT_ID)
 
 TRAINER_IMAGE := $(ARTIFACT_HOST)/$(PROJECT_ID)/$(ARTIFACT_REPO)/trainer:latest
-TRAINER_CPU ?= 1
-TRAINER_MEMORY ?= 1Gi
+TRAINER_CPU ?= 4
+TRAINER_MEMORY ?= 4Gi
 TRAINER_TASK_TIMEOUT ?= 24h
 
 build_trainer: check_deps require_cloud_env setup_builder

--- a/embodiedlab/continuous_navigation_env.py
+++ b/embodiedlab/continuous_navigation_env.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from math import atan2, ceil, cos, degrees, radians, sin, sqrt
+from dataclasses import dataclass
+from math import atan2, ceil, cos, degrees, radians, sin, sqrt, tan
 from typing import TYPE_CHECKING, ClassVar
 
 import gymnasium as gym
@@ -33,8 +34,22 @@ MIN_GOAL_PROGRESS_METERS = MOVEMENT_COLLISION_STEP_METERS
 RAY_STEP_METERS = MOVEMENT_COLLISION_STEP_METERS
 WIDE_ANGLE_DEGREES = 90.0
 REAR_ANGLE_DEGREES = 150.0
-CAMERA_FOV_DEGREES = 70.0
-CAMERA_NEAR_METERS = 0.05
+BOUNDARY_WALL_THICKNESS_METERS = 0.02
+RAY_EPSILON = 1e-6
+
+
+@dataclass(frozen=True)
+class CameraBox:
+    """Extruded box used by the semantic camera ray caster."""
+
+    center_x: float
+    center_z: float
+    half_x: float
+    half_z: float
+    height: float
+    rotation_cos: float = 1.0
+    rotation_sin: float = 0.0
+
 MAX_RANDOM_START_ATTEMPTS = 256
 RANDOM_START_CLEARANCE_RADIUS_METERS = 0.65
 RANDOM_START_CLEARANCE_PROBE_COUNT = 16
@@ -100,7 +115,6 @@ class ContinuousNavigationEnv(gym.Env):
         )
         self.robot_rotation_y_degrees = spec.robot_start.rotation_y_degrees
         self.steps = 0
-        self._camera_column_angle_offsets = self._build_camera_column_angle_offsets()
         self._obstacle_ids = tuple(obstacle.obstacle_id for obstacle in spec.obstacles)
         self._obstacle_center_x = np.array(
             [obstacle.center_x for obstacle in spec.obstacles],
@@ -118,6 +132,10 @@ class ContinuousNavigationEnv(gym.Env):
             [obstacle.size_z / 2.0 for obstacle in spec.obstacles],
             dtype=np.float32,
         )
+        self._obstacle_height = np.array(
+            [obstacle.height for obstacle in spec.obstacles],
+            dtype=np.float32,
+        )
         obstacle_angles = np.deg2rad(
             np.array(
                 [-obstacle.rotation_y_degrees for obstacle in spec.obstacles],
@@ -126,15 +144,7 @@ class ContinuousNavigationEnv(gym.Env):
         )
         self._obstacle_cos = np.cos(obstacle_angles)
         self._obstacle_sin = np.sin(obstacle_angles)
-
-    @staticmethod
-    def _build_camera_column_angle_offsets() -> np.ndarray:
-        column_ratios = (
-            np.arange(IMAGE_OBSERVATION_WIDTH, dtype=np.float32)
-            / max(1, IMAGE_OBSERVATION_WIDTH - 1)
-            - 0.5
-        )
-        return (column_ratios * CAMERA_FOV_DEGREES).astype(np.float32)
+        self._camera_ray_directions = self._build_camera_ray_directions()
 
     def _map_raw_action(
         self,
@@ -145,11 +155,12 @@ class ContinuousNavigationEnv(gym.Env):
             self.action_space.low,
             self.action_space.high,
         ).astype(np.float32)
+        applied_forward = 1.0 / (
+            1.0 + np.exp(-float(raw_action[FORWARD_ACTION_INDEX]))
+        )
+        applied_turn = float(raw_action[TURN_ACTION_INDEX]) / POLICY_TURN_ACTION_HIGH
         applied_action = np.array(
-            [
-                1.0 / (1.0 + np.exp(-float(raw_action[FORWARD_ACTION_INDEX]))),
-                float(raw_action[TURN_ACTION_INDEX]) / POLICY_TURN_ACTION_HIGH,
-            ],
+            [applied_forward, applied_turn],
             dtype=np.float32,
         )
         return raw_action, applied_action
@@ -261,26 +272,225 @@ class ContinuousNavigationEnv(gym.Env):
             ),
             dtype=np.float32,
         )
-        distances = self._camera_row_distances()
-        ray_degrees = self.robot_rotation_y_degrees + self._camera_column_angle_offsets
-        hit_distances, has_hit = self._ray_hits(ray_degrees)
-        collision_mask = (
-            (distances[:, None] >= hit_distances[None, :])
-            & has_hit[None, :]
+        directions = self._world_camera_ray_directions()
+        floor_distances = self._floor_intersection_distances(directions)
+        blocked_distances = self._blocked_intersection_distances(directions)
+
+        floor_mask = np.isfinite(floor_distances) & (
+            floor_distances <= blocked_distances
         )
-        image[1, :, :] = np.logical_not(collision_mask)
-        image[2, :, :] = collision_mask
+        blocked_mask = np.isfinite(blocked_distances) & (
+            blocked_distances < floor_distances
+        )
+        background_mask = ~(floor_mask | blocked_mask)
+
+        image[0, background_mask] = 1.0
+        image[1, floor_mask] = 1.0
+        image[2, blocked_mask] = 1.0
         return image
 
-    def _camera_row_distances(self) -> np.ndarray:
-        row_ratios = 1.0 - (
-            np.arange(IMAGE_OBSERVATION_HEIGHT, dtype=np.float32)
-            / max(1, IMAGE_OBSERVATION_HEIGHT - 1)
+    def _build_camera_ray_directions(self) -> np.ndarray:
+        camera = self.spec.camera
+        if (
+            camera.width != IMAGE_OBSERVATION_WIDTH
+            or camera.height != IMAGE_OBSERVATION_HEIGHT
+        ):
+            msg = "camera dimensions must match the policy observation shape"
+            raise ValueError(msg)
+
+        vertical_fov_radians = radians(camera.vertical_fov_degrees)
+        aspect = IMAGE_OBSERVATION_WIDTH / IMAGE_OBSERVATION_HEIGHT
+        half_height = tan(vertical_fov_radians / 2.0)
+        half_width = half_height * aspect
+        x = (
+            (np.arange(IMAGE_OBSERVATION_WIDTH, dtype=np.float32) + 0.5)
+            / IMAGE_OBSERVATION_WIDTH
+            * 2.0
+            - 1.0
+        ) * half_width
+        y = (
+            1.0
+            - (np.arange(IMAGE_OBSERVATION_HEIGHT, dtype=np.float32) + 0.5)
+            / IMAGE_OBSERVATION_HEIGHT
+            * 2.0
+        ) * half_height
+        ray_x, ray_y = np.meshgrid(x, y)
+        ray_z = np.ones_like(ray_x, dtype=np.float32)
+
+        pitch = radians(camera.pitch_degrees)
+        pitch_cos = cos(pitch)
+        pitch_sin = sin(pitch)
+        pitched_y = ray_y * pitch_cos - ray_z * pitch_sin
+        pitched_z = ray_y * pitch_sin + ray_z * pitch_cos
+        directions = np.stack((ray_x, pitched_y, pitched_z), axis=2)
+        norms = np.linalg.norm(directions, axis=2, keepdims=True)
+        return (directions / norms).astype(np.float32)
+
+    def _world_camera_ray_directions(self) -> np.ndarray:
+        yaw = radians(self.robot_rotation_y_degrees)
+        yaw_cos = cos(yaw)
+        yaw_sin = sin(yaw)
+        local = self._camera_ray_directions
+        world_x = local[:, :, 0] * yaw_cos + local[:, :, 2] * yaw_sin
+        world_y = local[:, :, 1]
+        world_z = -local[:, :, 0] * yaw_sin + local[:, :, 2] * yaw_cos
+        return np.stack((world_x, world_y, world_z), axis=2).astype(np.float32)
+
+    def _floor_intersection_distances(self, directions: np.ndarray) -> np.ndarray:
+        camera = self.spec.camera
+        dy = directions[:, :, 1]
+        distances = np.full(dy.shape, np.inf, dtype=np.float32)
+        downward = dy < -RAY_EPSILON
+        floor_distances = -camera.mount_height_meters / dy[downward]
+        valid = (
+            (floor_distances >= camera.near_clip_meters)
+            & (floor_distances <= camera.far_clip_meters)
         )
+        downward_indices = np.nonzero(downward)
+        distances[downward_indices[0][valid], downward_indices[1][valid]] = (
+            floor_distances[valid]
+        )
+        return distances
+
+    def _blocked_intersection_distances(self, directions: np.ndarray) -> np.ndarray:
+        camera = self.spec.camera
+        distances = np.full(
+            (IMAGE_OBSERVATION_HEIGHT, IMAGE_OBSERVATION_WIDTH),
+            np.inf,
+            dtype=np.float32,
+        )
+        for index in range(len(self._obstacle_ids)):
+            obstacle_distances = self._box_intersection_distances(
+                directions,
+                CameraBox(
+                    center_x=float(self._obstacle_center_x[index]),
+                    center_z=float(self._obstacle_center_z[index]),
+                    half_x=float(self._obstacle_half_x[index]),
+                    half_z=float(self._obstacle_half_z[index]),
+                    height=float(self._obstacle_height[index]),
+                    rotation_cos=float(self._obstacle_cos[index]),
+                    rotation_sin=float(self._obstacle_sin[index]),
+                ),
+            )
+            distances = np.minimum(distances, obstacle_distances)
+
+        for boundary in self._boundary_boxes():
+            boundary_distances = self._box_intersection_distances(
+                directions,
+                boundary,
+            )
+            distances = np.minimum(distances, boundary_distances)
+
+        distances[
+            (distances < camera.near_clip_meters)
+            | (distances > camera.far_clip_meters)
+        ] = np.inf
+        return distances
+
+    def _box_intersection_distances(
+        self,
+        directions: np.ndarray,
+        box: CameraBox,
+    ) -> np.ndarray:
+        origin_x = float(self.robot_pos[0]) - box.center_x
+        origin_z = float(self.robot_pos[1]) - box.center_z
+        rotation_cos = box.rotation_cos
+        rotation_sin = box.rotation_sin
+        local_origin_x = origin_x * rotation_cos - origin_z * rotation_sin
+        local_origin_z = origin_x * rotation_sin + origin_z * rotation_cos
+        local_direction_x = (
+            directions[:, :, 0] * rotation_cos
+            - directions[:, :, 2] * rotation_sin
+        )
+        local_direction_z = (
+            directions[:, :, 0] * rotation_sin
+            + directions[:, :, 2] * rotation_cos
+        )
+
+        t_min_x, t_max_x, valid_x = self._axis_intersection_interval(
+            local_origin_x,
+            local_direction_x,
+            -box.half_x,
+            box.half_x,
+        )
+        t_min_y, t_max_y, valid_y = self._axis_intersection_interval(
+            self.spec.camera.mount_height_meters,
+            directions[:, :, 1],
+            0.0,
+            box.height,
+        )
+        t_min_z, t_max_z, valid_z = self._axis_intersection_interval(
+            local_origin_z,
+            local_direction_z,
+            -box.half_z,
+            box.half_z,
+        )
+        t_enter = np.maximum(np.maximum(t_min_x, t_min_y), t_min_z)
+        t_exit = np.minimum(np.minimum(t_max_x, t_max_y), t_max_z)
+        valid = valid_x & valid_y & valid_z & (t_exit >= t_enter)
+        valid &= t_exit >= self.spec.camera.near_clip_meters
+        distances = np.full(t_enter.shape, np.inf, dtype=np.float32)
+        distances[valid] = np.maximum(
+            t_enter[valid],
+            self.spec.camera.near_clip_meters,
+        )
+        return distances
+
+    @staticmethod
+    def _axis_intersection_interval(
+        origin: float,
+        direction: np.ndarray,
+        min_value: float,
+        max_value: float,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        parallel = np.abs(direction) < RAY_EPSILON
+        valid = ~(parallel & ((origin < min_value) | (origin > max_value)))
+        safe_direction = np.where(parallel, 1.0, direction)
+        t1 = (min_value - origin) / safe_direction
+        t2 = (max_value - origin) / safe_direction
+        t_min = np.minimum(t1, t2).astype(np.float32)
+        t_max = np.maximum(t1, t2).astype(np.float32)
+        t_min[parallel] = -np.inf
+        t_max[parallel] = np.inf
+        return t_min, t_max, valid
+
+    def _boundary_boxes(self) -> tuple[CameraBox, ...]:
+        bounds = self.spec.bounds
+        span_x = bounds.max_x - bounds.min_x
+        span_z = bounds.max_z - bounds.min_z
+        center_x = (bounds.min_x + bounds.max_x) / 2.0
+        center_z = (bounds.min_z + bounds.max_z) / 2.0
+        height = max([2.0, *(float(value) for value in self._obstacle_height)])
         return (
-            CAMERA_NEAR_METERS
-            + row_ratios * (self.spec.distance_sensor_range_meters - CAMERA_NEAR_METERS)
-        ).astype(np.float32)
+            CameraBox(
+                center_x=bounds.min_x,
+                center_z=center_z,
+                half_x=BOUNDARY_WALL_THICKNESS_METERS / 2.0,
+                half_z=span_z / 2.0,
+                height=height,
+            ),
+            CameraBox(
+                center_x=bounds.max_x,
+                center_z=center_z,
+                half_x=BOUNDARY_WALL_THICKNESS_METERS / 2.0,
+                half_z=span_z / 2.0,
+                height=height,
+            ),
+            CameraBox(
+                center_x=center_x,
+                center_z=bounds.min_z,
+                half_x=span_x / 2.0,
+                half_z=BOUNDARY_WALL_THICKNESS_METERS / 2.0,
+                height=height,
+            ),
+            CameraBox(
+                center_x=center_x,
+                center_z=bounds.max_z,
+                half_x=span_x / 2.0,
+                half_z=BOUNDARY_WALL_THICKNESS_METERS / 2.0,
+                height=height,
+            ),
+        )
 
     def _valid_random_start_position(self, position: np.ndarray) -> bool:
         return (

--- a/embodiedlab/continuous_navigation_env.py
+++ b/embodiedlab/continuous_navigation_env.py
@@ -145,6 +145,7 @@ class ContinuousNavigationEnv(gym.Env):
         self._obstacle_cos = np.cos(obstacle_angles)
         self._obstacle_sin = np.sin(obstacle_angles)
         self._camera_ray_directions = self._build_camera_ray_directions()
+        self._camera_mount_height_meters = spec.camera.mount_height_meters
 
     def _map_raw_action(
         self,
@@ -284,9 +285,8 @@ class ContinuousNavigationEnv(gym.Env):
         )
         background_mask = ~(floor_mask | blocked_mask)
 
-        image[0, background_mask] = 1.0
         image[1, floor_mask] = 1.0
-        image[2, blocked_mask] = 1.0
+        image[2, blocked_mask | background_mask] = 1.0
         return image
 
     def _build_camera_ray_directions(self) -> np.ndarray:
@@ -336,12 +336,23 @@ class ContinuousNavigationEnv(gym.Env):
         world_z = -local[:, :, 0] * yaw_sin + local[:, :, 2] * yaw_cos
         return np.stack((world_x, world_y, world_z), axis=2).astype(np.float32)
 
+    def _sample_camera_mount_height_meters(self) -> float:
+        camera = self.spec.camera
+        if camera.mount_height_min_meters == camera.mount_height_max_meters:
+            return camera.mount_height_min_meters
+        return float(
+            self.np_random.uniform(
+                camera.mount_height_min_meters,
+                camera.mount_height_max_meters,
+            ),
+        )
+
     def _floor_intersection_distances(self, directions: np.ndarray) -> np.ndarray:
         camera = self.spec.camera
         dy = directions[:, :, 1]
         distances = np.full(dy.shape, np.inf, dtype=np.float32)
         downward = dy < -RAY_EPSILON
-        floor_distances = -camera.mount_height_meters / dy[downward]
+        floor_distances = -self._camera_mount_height_meters / dy[downward]
         valid = (
             (floor_distances >= camera.near_clip_meters)
             & (floor_distances <= camera.far_clip_meters)
@@ -414,7 +425,7 @@ class ContinuousNavigationEnv(gym.Env):
             box.half_x,
         )
         t_min_y, t_max_y, valid_y = self._axis_intersection_interval(
-            self.spec.camera.mount_height_meters,
+            self._camera_mount_height_meters,
             directions[:, :, 1],
             0.0,
             box.height,
@@ -625,6 +636,7 @@ class ContinuousNavigationEnv(gym.Env):
             "collision": collision_id is not None,
             "collision_id": collision_id,
             "front_distance": self._front_distance(),
+            "camera_mount_height_meters": self._camera_mount_height_meters,
             "robot_x": float(self.robot_pos[0]),
             "robot_z": float(self.robot_pos[1]),
             "robot_rotation_y_degrees": float(self.robot_rotation_y_degrees),
@@ -691,6 +703,7 @@ class ContinuousNavigationEnv(gym.Env):
     ) -> tuple[dict[str, np.ndarray], dict]:
         """Reset the environment to the scenario start pose."""
         super().reset(seed=seed)
+        self._camera_mount_height_meters = self._sample_camera_mount_height_meters()
         if self.randomize_start:
             position, rotation_y_degrees = self._sample_random_start()
             self.robot_pos = position

--- a/embodiedlab/schemas.py
+++ b/embodiedlab/schemas.py
@@ -120,6 +120,7 @@ class StaticWall(BaseModel):
     id: str = Field(min_length=1)
     center: Position2D
     size: Size2D
+    height: float = Field(default=2.0, gt=0)
     rotation_y_degrees: float = 0.0
 
 
@@ -130,6 +131,7 @@ class StaticObstacle(BaseModel):
     shape: Literal["box"] = "box"
     center: Position2D
     size: Size2D
+    height: float = Field(default=1.0, gt=0)
     rotation_y_degrees: float = 0.0
 
 
@@ -226,9 +228,14 @@ class ForwardCameraSensor(BaseModel):
 
     id: str = Field(min_length=1)
     type: Literal[SensorType.FORWARD_CAMERA] = SensorType.FORWARD_CAMERA
-    width: int = Field(default=84, ge=1)
+    width: int = Field(default=112, ge=1)
     height: int = Field(default=84, ge=1)
     semantic_mode: SemanticMode = SemanticMode.TRAVERSABLE_VS_BLOCKED
+    mount_height_meters: float = Field(default=0.6, gt=0)
+    pitch_degrees: float = Field(default=0.0)
+    vertical_fov_degrees: float = Field(default=60.0, gt=0, lt=180)
+    near_clip_meters: float = Field(default=0.05, gt=0)
+    far_clip_meters: float | None = Field(default=None, gt=0)
 
 
 class DistanceSensor(BaseModel):

--- a/embodiedlab/schemas.py
+++ b/embodiedlab/schemas.py
@@ -232,10 +232,29 @@ class ForwardCameraSensor(BaseModel):
     height: int = Field(default=84, ge=1)
     semantic_mode: SemanticMode = SemanticMode.TRAVERSABLE_VS_BLOCKED
     mount_height_meters: float = Field(default=0.6, gt=0)
+    mount_height_min_meters: float | None = Field(default=None, gt=0)
+    mount_height_max_meters: float | None = Field(default=None, gt=0)
     pitch_degrees: float = Field(default=0.0)
-    vertical_fov_degrees: float = Field(default=60.0, gt=0, lt=180)
+    vertical_fov_degrees: float = Field(default=70.0, gt=0, lt=180)
     near_clip_meters: float = Field(default=0.05, gt=0)
-    far_clip_meters: float | None = Field(default=None, gt=0)
+    far_clip_meters: float = Field(default=100.0, gt=0)
+
+    @model_validator(mode="after")
+    def validate_mount_height_range(self) -> ForwardCameraSensor:
+        """Require a complete, ordered optional camera height range."""
+        has_min = self.mount_height_min_meters is not None
+        has_max = self.mount_height_max_meters is not None
+        if has_min != has_max:
+            msg = "camera mount height range requires both min and max values"
+            raise ValueError(msg)
+        if (
+            self.mount_height_min_meters is not None
+            and self.mount_height_max_meters is not None
+            and self.mount_height_min_meters > self.mount_height_max_meters
+        ):
+            msg = "camera mount height min must be less than or equal to max"
+            raise ValueError(msg)
+        return self
 
 
 class DistanceSensor(BaseModel):

--- a/embodiedlab/training/training_converter.py
+++ b/embodiedlab/training/training_converter.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from math import hypot
 
 from embodiedlab.schemas import (
     CollisionRewardComponent,
@@ -89,23 +88,24 @@ def _forward_camera_sensor(scenario: ScenarioBundle) -> ForwardCameraSensor:
     return ForwardCameraSensor(id="front_camera")
 
 
-def _default_camera_far_clip_meters(scenario: ScenarioBundle) -> float:
-    bounds = scenario.world.bounds
-    return hypot(bounds.max.x - bounds.min.x, bounds.max.z - bounds.min.z)
-
-
 def _camera_spec(scenario: ScenarioBundle) -> ContinuousCameraSpec:
     camera = _forward_camera_sensor(scenario)
     far_clip_meters = camera.far_clip_meters
-    if far_clip_meters is None:
-        far_clip_meters = _default_camera_far_clip_meters(scenario)
     if camera.width != POLICY_CAMERA_WIDTH or camera.height != POLICY_CAMERA_HEIGHT:
         msg = "forward camera size must be 112x84 for the current policy network"
         raise ValueError(msg)
+    mount_height_min_meters = camera.mount_height_min_meters
+    if mount_height_min_meters is None:
+        mount_height_min_meters = camera.mount_height_meters
+    mount_height_max_meters = camera.mount_height_max_meters
+    if mount_height_max_meters is None:
+        mount_height_max_meters = camera.mount_height_meters
     return ContinuousCameraSpec(
         width=camera.width,
         height=camera.height,
         mount_height_meters=camera.mount_height_meters,
+        mount_height_min_meters=mount_height_min_meters,
+        mount_height_max_meters=mount_height_max_meters,
         pitch_degrees=camera.pitch_degrees,
         vertical_fov_degrees=camera.vertical_fov_degrees,
         near_clip_meters=camera.near_clip_meters,

--- a/embodiedlab/training/training_converter.py
+++ b/embodiedlab/training/training_converter.py
@@ -25,8 +25,10 @@ from embodiedlab.training.training_models import (
     ContinuousRobotStart,
 )
 
-POLICY_CAMERA_WIDTH = 112
-POLICY_CAMERA_HEIGHT = 84
+POLICY_CAMERA_WIDTH = ForwardCameraSensor(id="front_camera").width
+POLICY_CAMERA_HEIGHT = ForwardCameraSensor(id="front_camera").height
+POLICY_FORWARD_STEP_METERS = 0.2
+POLICY_TURN_DEGREES_PER_STEP = 15.0
 
 
 @dataclass(frozen=True)
@@ -78,7 +80,7 @@ def _distance_sensor_range(scenario: ScenarioBundle) -> float:
     for sensor in scenario.sensors:
         if isinstance(sensor, DistanceSensor):
             return sensor.range_meters
-    return 5.0
+    return DistanceSensor(id="front_distance").range_meters
 
 
 def _forward_camera_sensor(scenario: ScenarioBundle) -> ForwardCameraSensor:
@@ -114,16 +116,9 @@ def _camera_spec(scenario: ScenarioBundle) -> ContinuousCameraSpec:
 
 
 def _reward_weights(scenario: ScenarioBundle) -> ContinuousRewardWeights:
-    weights = ContinuousRewardWeights()
     values = {
-        "goal_reached": weights.goal_reached,
-        "goal_progress": weights.goal_progress,
-        "collision_penalty": weights.collision_penalty,
-        "step_penalty": weights.step_penalty,
-        "wide_angle_penalty": weights.wide_angle_penalty,
-        "rear_angle_penalty": weights.rear_angle_penalty,
-        "inactive_penalty": weights.inactive_penalty,
-        "movement_threshold": weights.movement_threshold,
+        component.name: component.weight
+        for component in ScenarioBundle().reward.components
     }
     for component in scenario.reward.components:
         if (
@@ -206,4 +201,6 @@ def convert_submission_to_spec(
         distance_sensor_range_meters=distance_sensor_range_meters,
         camera=_camera_spec(scenario),
         reward_weights=_reward_weights(scenario),
+        forward_step_meters=POLICY_FORWARD_STEP_METERS,
+        turn_degrees_per_step=POLICY_TURN_DEGREES_PER_STEP,
     )

--- a/embodiedlab/training/training_converter.py
+++ b/embodiedlab/training/training_converter.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from math import hypot
 
 from embodiedlab.schemas import (
     CollisionRewardComponent,
     DistanceDeltaRewardComponent,
     DistanceSensor,
+    ForwardCameraSensor,
     PerStepRewardComponent,
     ScenarioBundle,
     StaticObstacle,
@@ -17,11 +19,15 @@ from embodiedlab.schemas import (
 from embodiedlab.training.training_models import (
     ContinuousBounds,
     ContinuousBoxObstacle,
+    ContinuousCameraSpec,
     ContinuousGoal,
     ContinuousNavigationSpec,
     ContinuousRewardWeights,
     ContinuousRobotStart,
 )
+
+POLICY_CAMERA_WIDTH = 112
+POLICY_CAMERA_HEIGHT = 84
 
 
 @dataclass(frozen=True)
@@ -56,13 +62,13 @@ def describe_runtime_conversion(
         source_coordinate_system=scenario.world.coordinate_system.value,
         runtime_coordinate_system="envforge_xz_meters",
         coordinate_mapping="direct_envforge_xz_meters",
-        omitted_contract_fields=("sensors.forward_camera.image_observation",),
+        omitted_contract_fields=(),
         lossy=True,
         notes=(
             "Runtime positions, rotations, bounds, goal radius, static walls, "
-            "and static obstacle footprints stay in EnvForge x/z meters.",
-            "Forward camera output remains an abstraction at this runtime layer; "
-            "distance sensor range is represented directly.",
+            "static obstacle footprints, and object heights stay in EnvForge meters.",
+            "Forward camera output is rendered as a semantic 2.5D projection; "
+            "materials, lighting, shadows, and Unity post-processing remain lossy.",
             "Supported declarative reward component weights are carried into "
             "the continuous runtime spec.",
         ),
@@ -74,6 +80,37 @@ def _distance_sensor_range(scenario: ScenarioBundle) -> float:
         if isinstance(sensor, DistanceSensor):
             return sensor.range_meters
     return 5.0
+
+
+def _forward_camera_sensor(scenario: ScenarioBundle) -> ForwardCameraSensor:
+    for sensor in scenario.sensors:
+        if isinstance(sensor, ForwardCameraSensor):
+            return sensor
+    return ForwardCameraSensor(id="front_camera")
+
+
+def _default_camera_far_clip_meters(scenario: ScenarioBundle) -> float:
+    bounds = scenario.world.bounds
+    return hypot(bounds.max.x - bounds.min.x, bounds.max.z - bounds.min.z)
+
+
+def _camera_spec(scenario: ScenarioBundle) -> ContinuousCameraSpec:
+    camera = _forward_camera_sensor(scenario)
+    far_clip_meters = camera.far_clip_meters
+    if far_clip_meters is None:
+        far_clip_meters = _default_camera_far_clip_meters(scenario)
+    if camera.width != POLICY_CAMERA_WIDTH or camera.height != POLICY_CAMERA_HEIGHT:
+        msg = "forward camera size must be 112x84 for the current policy network"
+        raise ValueError(msg)
+    return ContinuousCameraSpec(
+        width=camera.width,
+        height=camera.height,
+        mount_height_meters=camera.mount_height_meters,
+        pitch_degrees=camera.pitch_degrees,
+        vertical_fov_degrees=camera.vertical_fov_degrees,
+        near_clip_meters=camera.near_clip_meters,
+        far_clip_meters=far_clip_meters,
+    )
 
 
 def _reward_weights(scenario: ScenarioBundle) -> ContinuousRewardWeights:
@@ -112,6 +149,7 @@ def _wall_to_obstacle(wall_index: int, wall: StaticWall) -> ContinuousBoxObstacl
         center_z=wall.center.z,
         size_x=wall.size.x,
         size_z=wall.size.z,
+        height=wall.height,
         rotation_y_degrees=wall.rotation_y_degrees,
     )
 
@@ -123,6 +161,7 @@ def _box_to_obstacle(obstacle: StaticObstacle) -> ContinuousBoxObstacle:
         center_z=obstacle.center.z,
         size_x=obstacle.size.x,
         size_z=obstacle.size.z,
+        height=obstacle.height,
         rotation_y_degrees=obstacle.rotation_y_degrees,
     )
 
@@ -142,6 +181,7 @@ def convert_submission_to_spec(
         ),
         *(_box_to_obstacle(obstacle) for obstacle in scenario.world.static_obstacles),
     ]
+    distance_sensor_range_meters = _distance_sensor_range(scenario)
 
     return ContinuousNavigationSpec(
         bounds=ContinuousBounds(
@@ -163,6 +203,7 @@ def convert_submission_to_spec(
             rotation_y_degrees=start_pose.rotation_y_degrees,
         ),
         robot_type=scenario.robot.type.value,
-        distance_sensor_range_meters=_distance_sensor_range(scenario),
+        distance_sensor_range_meters=distance_sensor_range_meters,
+        camera=_camera_spec(scenario),
         reward_weights=_reward_weights(scenario),
     )

--- a/embodiedlab/training/training_models.py
+++ b/embodiedlab/training/training_models.py
@@ -49,15 +49,17 @@ class ContinuousRobotStart:
 
 @dataclass(frozen=True)
 class ContinuousCameraSpec:
-    """Fixed forward camera parameters for semantic 2.5D rendering."""
+    """Forward camera parameters for semantic 2.5D rendering."""
 
     width: int = 112
     height: int = 84
     mount_height_meters: float = 0.6
+    mount_height_min_meters: float = 0.6
+    mount_height_max_meters: float = 0.6
     pitch_degrees: float = 0.0
-    vertical_fov_degrees: float = 60.0
+    vertical_fov_degrees: float = 70.0
     near_clip_meters: float = 0.05
-    far_clip_meters: float = 5.0
+    far_clip_meters: float = 100.0
 
 
 @dataclass(frozen=True)

--- a/embodiedlab/training/training_models.py
+++ b/embodiedlab/training/training_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
@@ -24,8 +24,8 @@ class ContinuousBoxObstacle:
     center_z: float
     size_x: float
     size_z: float
-    height: float = 2.0
-    rotation_y_degrees: float = 0.0
+    height: float
+    rotation_y_degrees: float
 
 
 @dataclass(frozen=True)
@@ -51,29 +51,29 @@ class ContinuousRobotStart:
 class ContinuousCameraSpec:
     """Forward camera parameters for semantic 2.5D rendering."""
 
-    width: int = 112
-    height: int = 84
-    mount_height_meters: float = 0.6
-    mount_height_min_meters: float = 0.6
-    mount_height_max_meters: float = 0.6
-    pitch_degrees: float = 0.0
-    vertical_fov_degrees: float = 70.0
-    near_clip_meters: float = 0.05
-    far_clip_meters: float = 100.0
+    width: int
+    height: int
+    mount_height_meters: float
+    mount_height_min_meters: float
+    mount_height_max_meters: float
+    pitch_degrees: float
+    vertical_fov_degrees: float
+    near_clip_meters: float
+    far_clip_meters: float
 
 
 @dataclass(frozen=True)
 class ContinuousRewardWeights:
     """Reward weights used by the continuous EnvForge runtime."""
 
-    goal_reached: float = 100.0
-    goal_progress: float = 0.1
-    collision_penalty: float = -50.0
-    step_penalty: float = -0.01
-    wide_angle_penalty: float = -0.1
-    rear_angle_penalty: float = -5.0
-    inactive_penalty: float = -0.1
-    movement_threshold: float = 0.001
+    goal_reached: float
+    goal_progress: float
+    collision_penalty: float
+    step_penalty: float
+    wide_angle_penalty: float
+    rear_angle_penalty: float
+    inactive_penalty: float
+    movement_threshold: float
 
 
 @dataclass(frozen=True)
@@ -85,10 +85,8 @@ class ContinuousNavigationSpec:
     goal: ContinuousGoal
     robot_start: ContinuousRobotStart
     robot_type: str
-    distance_sensor_range_meters: float = 5.0
-    camera: ContinuousCameraSpec = field(default_factory=ContinuousCameraSpec)
-    reward_weights: ContinuousRewardWeights = field(
-        default_factory=ContinuousRewardWeights,
-    )
-    forward_step_meters: float = 0.2
-    turn_degrees_per_step: float = 15.0
+    distance_sensor_range_meters: float
+    camera: ContinuousCameraSpec
+    reward_weights: ContinuousRewardWeights
+    forward_step_meters: float
+    turn_degrees_per_step: float

--- a/embodiedlab/training/training_models.py
+++ b/embodiedlab/training/training_models.py
@@ -24,6 +24,7 @@ class ContinuousBoxObstacle:
     center_z: float
     size_x: float
     size_z: float
+    height: float = 2.0
     rotation_y_degrees: float = 0.0
 
 
@@ -44,6 +45,19 @@ class ContinuousRobotStart:
     x: float
     z: float
     rotation_y_degrees: float
+
+
+@dataclass(frozen=True)
+class ContinuousCameraSpec:
+    """Fixed forward camera parameters for semantic 2.5D rendering."""
+
+    width: int = 112
+    height: int = 84
+    mount_height_meters: float = 0.6
+    pitch_degrees: float = 0.0
+    vertical_fov_degrees: float = 60.0
+    near_clip_meters: float = 0.05
+    far_clip_meters: float = 5.0
 
 
 @dataclass(frozen=True)
@@ -70,6 +84,7 @@ class ContinuousNavigationSpec:
     robot_start: ContinuousRobotStart
     robot_type: str
     distance_sensor_range_meters: float = 5.0
+    camera: ContinuousCameraSpec = field(default_factory=ContinuousCameraSpec)
     reward_weights: ContinuousRewardWeights = field(
         default_factory=ContinuousRewardWeights,
     )

--- a/tests/test_continuous_navigation_env.py
+++ b/tests/test_continuous_navigation_env.py
@@ -341,25 +341,25 @@ def test_continuous_env_blocks_thin_obstacle_between_movement_endpoints():
     assert next_info["collision"] is True
 
 
-def test_segmentation_observation_marks_pixels_behind_first_ray_hit_blocked():
+def test_segmentation_observation_renders_near_wall_as_large_blocked_surface():
     scenario = ScenarioBundle(
         world={
             "bounds": {
                 "min": {"x": -2.0, "z": -2.0},
-                "max": {"x": 2.0, "z": 2.0},
+                "max": {"x": 2.0, "z": 4.0},
             },
             "static_obstacles": [
                 {
-                    "id": "thin_wall",
+                    "id": "near_wall",
                     "shape": "box",
-                    "center": {"x": 0.0, "z": 0.8},
-                    "size": {"x": 1.0, "z": 0.02},
-                    "rotation_y_degrees": 0.0,
+                    "center": {"x": 0.0, "z": 0.4},
+                    "size": {"x": 3.0, "z": 0.02},
+                    "height": 2.0,
                 },
             ],
             "goal": {
                 "id": "goal_001",
-                "position": {"x": 1.5, "z": 1.5},
+                "position": {"x": 1.5, "z": 3.5},
                 "radius": 0.5,
             },
         },
@@ -370,7 +370,12 @@ def test_segmentation_observation_marks_pixels_behind_first_ray_hit_blocked():
             },
         },
         sensors=[
-            {"id": "front_camera", "type": "forward_camera"},
+            {
+                "id": "front_camera",
+                "type": "forward_camera",
+                "mount_height_meters": 0.6,
+                "far_clip_meters": 3.0,
+            },
             {"id": "front_distance", "type": "distance_sensor", "range_meters": 3.0},
         ],
     )
@@ -378,20 +383,63 @@ def test_segmentation_observation_marks_pixels_behind_first_ray_hit_blocked():
         spec=convert_submission_to_spec(scenario),
         max_steps=10,
     )
+
+    obs, _info = env.reset()
+
+    assert obs["obs_0"][2].mean() > 0.95
+    assert obs["obs_0"][2, 0, IMAGE_OBSERVATION_WIDTH // 2] == 1.0
+    assert obs["obs_0"][2, -1, IMAGE_OBSERVATION_WIDTH // 2] == 1.0
+
+
+def test_segmentation_observation_uses_object_height_in_camera_projection():
+    scenario = ScenarioBundle(
+        world={
+            "bounds": {
+                "min": {"x": -2.0, "z": -2.0},
+                "max": {"x": 2.0, "z": 4.0},
+            },
+            "static_obstacles": [
+                {
+                    "id": "low_box",
+                    "shape": "box",
+                    "center": {"x": 0.0, "z": 0.8},
+                    "size": {"x": 1.5, "z": 0.2},
+                    "height": 0.2,
+                },
+            ],
+            "goal": {
+                "id": "goal_001",
+                "position": {"x": 1.5, "z": 3.5},
+                "radius": 0.5,
+            },
+        },
+        robot={
+            "start_pose": {
+                "position": {"x": 0.0, "z": 0.0},
+                "rotation_y_degrees": 0.0,
+            },
+        },
+        sensors=[
+            {
+                "id": "front_camera",
+                "type": "forward_camera",
+                "mount_height_meters": 0.6,
+                "far_clip_meters": 3.0,
+            },
+            {"id": "front_distance", "type": "distance_sensor", "range_meters": 3.0},
+        ],
+    )
+    env = ContinuousNavigationEnv(spec=convert_submission_to_spec(scenario))
+
     obs, _info = env.reset()
 
     center_column = IMAGE_OBSERVATION_WIDTH // 2
-    distances = env._camera_row_distances()  # noqa: SLF001
-    hit_distance = env._front_distance()  # noqa: SLF001
-    first_blocked_row = int(np.nonzero(distances >= hit_distance)[0][-1])
-
-    assert hit_distance == pytest.approx(0.795)
-    assert obs["obs_0"][2, first_blocked_row, center_column] == 1.0
-    assert obs["obs_0"][2, 0, center_column] == 1.0
-    assert obs["obs_0"][1, -1, center_column] == 1.0
+    assert obs["obs_0"][2, 0, center_column] == 0.0
+    assert obs["obs_0"][2, -1, center_column] == 1.0
+    assert 0.0 < obs["obs_0"][2].mean() < 0.2
 
 
-def test_segmentation_observation_keeps_no_hit_rays_free_at_max_range():
+def test_segmentation_observation_renders_floor_and_background_without_hits():
     scenario = ScenarioBundle(
         world={
             "bounds": {
@@ -411,7 +459,7 @@ def test_segmentation_observation_keeps_no_hit_rays_free_at_max_range():
             },
         },
         sensors=[
-            {"id": "front_camera", "type": "forward_camera"},
+            {"id": "front_camera", "type": "forward_camera", "far_clip_meters": 3.0},
             {"id": "front_distance", "type": "distance_sensor", "range_meters": 3.0},
         ],
     )
@@ -419,8 +467,11 @@ def test_segmentation_observation_keeps_no_hit_rays_free_at_max_range():
 
     obs, _info = env.reset()
 
+    center_column = IMAGE_OBSERVATION_WIDTH // 2
     assert np.all(obs["obs_0"][2] == 0.0)
-    assert np.all(obs["obs_0"][1] == 1.0)
+    assert obs["obs_0"][0, 0, center_column] == 1.0
+    assert obs["obs_0"][1, -1, center_column] == 1.0
+    assert obs["obs_0"][0].mean() > obs["obs_0"][1].mean()
 
 
 def test_front_distance_detects_thin_obstacle_between_coarse_sensor_samples():

--- a/tests/test_continuous_navigation_env.py
+++ b/tests/test_continuous_navigation_env.py
@@ -72,6 +72,8 @@ def test_continuous_runtime_conversion_preserves_envforge_coordinates():
     assert spec.robot_start.x == 1.9
     assert spec.robot_start.rotation_y_degrees == 90.0
     assert spec.distance_sensor_range_meters == 7.5
+    assert spec.camera.mount_height_min_meters == 0.6
+    assert spec.camera.mount_height_max_meters == 0.6
     assert [obstacle.obstacle_id for obstacle in spec.obstacles] == [
         "wall_001",
         "box_001",
@@ -434,9 +436,10 @@ def test_segmentation_observation_uses_object_height_in_camera_projection():
     obs, _info = env.reset()
 
     center_column = IMAGE_OBSERVATION_WIDTH // 2
-    assert obs["obs_0"][2, 0, center_column] == 0.0
-    assert obs["obs_0"][2, -1, center_column] == 1.0
-    assert 0.0 < obs["obs_0"][2].mean() < 0.2
+    assert obs["obs_0"][2, 0, center_column] == 1.0
+    assert obs["obs_0"][1].mean() > 0.1
+    assert obs["obs_0"][2].mean() > 0.1
+    assert np.all(obs["obs_0"][0] == 0.0)
 
 
 def test_segmentation_observation_renders_floor_and_background_without_hits():
@@ -468,10 +471,11 @@ def test_segmentation_observation_renders_floor_and_background_without_hits():
     obs, _info = env.reset()
 
     center_column = IMAGE_OBSERVATION_WIDTH // 2
-    assert np.all(obs["obs_0"][2] == 0.0)
-    assert obs["obs_0"][0, 0, center_column] == 1.0
+    assert np.all(obs["obs_0"][0] == 0.0)
+    assert obs["obs_0"][2, 0, center_column] == 1.0
     assert obs["obs_0"][1, -1, center_column] == 1.0
-    assert obs["obs_0"][0].mean() > obs["obs_0"][1].mean()
+    assert obs["obs_0"][2].mean() > 0.4
+    assert obs["obs_0"][1].mean() > 0.3
 
 
 def test_front_distance_detects_thin_obstacle_between_coarse_sensor_samples():
@@ -582,4 +586,29 @@ def test_continuous_env_randomizes_start_pose_when_enabled():
     assert second_info["robot_z"] == pytest.approx(info["robot_z"])
     assert second_info["robot_rotation_y_degrees"] == pytest.approx(
         info["robot_rotation_y_degrees"],
+    )
+
+
+def test_continuous_env_randomizes_camera_mount_height_per_episode():
+    scenario = ScenarioBundle(
+        sensors=[
+            {
+                "id": "front_camera",
+                "type": "forward_camera",
+                "mount_height_meters": 0.6,
+                "mount_height_min_meters": 0.1,
+                "mount_height_max_meters": 1.0,
+            },
+        ],
+    )
+    spec = convert_submission_to_spec(scenario)
+    env = ContinuousNavigationEnv(spec=spec, max_steps=10)
+
+    _obs, first_info = env.reset(seed=123)
+    _obs, second_info = env.reset()
+
+    assert 0.1 <= first_info["camera_mount_height_meters"] <= 1.0
+    assert 0.1 <= second_info["camera_mount_height_meters"] <= 1.0
+    assert second_info["camera_mount_height_meters"] != pytest.approx(
+        first_info["camera_mount_height_meters"],
     )

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -123,7 +123,34 @@ def test_scenario_bundle_accepts_documented_shape():
     assert scenario.sensors[0].width == 112
     assert scenario.sensors[0].height == 84
     assert scenario.sensors[0].mount_height_meters == 0.6
+    assert scenario.sensors[0].mount_height_min_meters is None
+    assert scenario.sensors[0].mount_height_max_meters is None
     assert isinstance(scenario.reward.components[0], DistanceDeltaRewardComponent)
+
+
+def test_forward_camera_mount_height_range_must_be_complete_and_ordered():
+    with pytest.raises(ValidationError, match="requires both min and max"):
+        ScenarioBundle(
+            sensors=[
+                {
+                    "id": "front_camera",
+                    "type": "forward_camera",
+                    "mount_height_min_meters": 0.1,
+                },
+            ],
+        )
+
+    with pytest.raises(ValidationError, match="min must be less than or equal"):
+        ScenarioBundle(
+            sensors=[
+                {
+                    "id": "front_camera",
+                    "type": "forward_camera",
+                    "mount_height_min_meters": 1.0,
+                    "mount_height_max_meters": 0.1,
+                },
+            ],
+        )
 
 
 def test_envforge_navigation_fixture_matches_scenario_bundle_contract():

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -83,9 +83,14 @@ def test_scenario_bundle_accepts_documented_shape():
                 {
                     "id": "front_camera",
                     "type": "forward_camera",
-                    "width": 84,
+                    "width": 112,
                     "height": 84,
                     "semantic_mode": "traversable_vs_blocked",
+                    "mount_height_meters": 0.6,
+                    "pitch_degrees": 0.0,
+                    "vertical_fov_degrees": 60.0,
+                    "near_clip_meters": 0.05,
+                    "far_clip_meters": 5.0,
                 },
                 {
                     "id": "front_distance",
@@ -115,6 +120,9 @@ def test_scenario_bundle_accepts_documented_shape():
 
     assert scenario.scenario_id == "scenario_custom"
     assert scenario.world.static_obstacles[0].id == "box_001"
+    assert scenario.sensors[0].width == 112
+    assert scenario.sensors[0].height == 84
+    assert scenario.sensors[0].mount_height_meters == 0.6
     assert isinstance(scenario.reward.components[0], DistanceDeltaRewardComponent)
 
 

--- a/tests/test_training_converter.py
+++ b/tests/test_training_converter.py
@@ -42,6 +42,7 @@ def test_convert_scenario_to_continuous_runtime_spec():
                     "id": "wall_001",
                     "center": {"x": 0.0, "z": 4.0},
                     "size": {"x": 8.0, "z": 0.2},
+                    "height": 2.5,
                     "rotation_y_degrees": 90.0,
                 },
             ],
@@ -51,6 +52,7 @@ def test_convert_scenario_to_continuous_runtime_spec():
                     "shape": "box",
                     "center": {"x": 4.75, "z": 5.25},
                     "size": {"x": 1.2, "z": 0.8},
+                    "height": 0.75,
                     "rotation_y_degrees": 45.0,
                 },
             ],
@@ -67,7 +69,15 @@ def test_convert_scenario_to_continuous_runtime_spec():
             },
         },
         sensors=[
-            {"id": "front_camera", "type": "forward_camera"},
+            {
+                "id": "front_camera",
+                "type": "forward_camera",
+                "mount_height_meters": 0.7,
+                "pitch_degrees": 5.0,
+                "vertical_fov_degrees": 55.0,
+                "near_clip_meters": 0.1,
+                "far_clip_meters": 6.5,
+            },
             {"id": "front_distance", "type": "distance_sensor", "range_meters": 7.5},
         ],
         reward={
@@ -103,6 +113,11 @@ def test_convert_scenario_to_continuous_runtime_spec():
     assert spec.robot_start.x == 1.9
     assert spec.robot_start.rotation_y_degrees == 90.0
     assert spec.distance_sensor_range_meters == 7.5
+    assert spec.camera.mount_height_meters == 0.7
+    assert spec.camera.pitch_degrees == 5.0
+    assert spec.camera.vertical_fov_degrees == 55.0
+    assert spec.camera.near_clip_meters == 0.1
+    assert spec.camera.far_clip_meters == 6.5
     assert spec.reward_weights.goal_reached == 101.0
     assert spec.reward_weights.goal_progress == 0.25
     assert spec.reward_weights.collision_penalty == -12.0
@@ -115,7 +130,29 @@ def test_convert_scenario_to_continuous_runtime_spec():
         "wall_001",
         "box_001",
     ]
+    assert spec.obstacles[0].height == 2.5
+    assert spec.obstacles[1].height == 0.75
     assert spec.obstacles[1].rotation_y_degrees == 45.0
+
+
+def test_camera_far_clip_defaults_to_world_diagonal_when_unspecified():
+    scenario = ScenarioBundle(
+        world={
+            "bounds": {
+                "min": {"x": -5.0, "z": -2.0},
+                "max": {"x": 20.0, "z": 15.0},
+            },
+        },
+        sensors=[
+            {"id": "front_camera", "type": "forward_camera"},
+            {"id": "front_distance", "type": "distance_sensor", "range_meters": 7.5},
+        ],
+    )
+
+    spec = convert_submission_to_spec(scenario)
+
+    assert spec.distance_sensor_range_meters == 7.5
+    assert spec.camera.far_clip_meters == pytest.approx(((25.0**2) + (17.0**2)) ** 0.5)
 
 
 def test_parse_scenario_bundle_rejects_invalid_dict():

--- a/tests/test_training_converter.py
+++ b/tests/test_training_converter.py
@@ -73,6 +73,8 @@ def test_convert_scenario_to_continuous_runtime_spec():
                 "id": "front_camera",
                 "type": "forward_camera",
                 "mount_height_meters": 0.7,
+                "mount_height_min_meters": 0.1,
+                "mount_height_max_meters": 1.0,
                 "pitch_degrees": 5.0,
                 "vertical_fov_degrees": 55.0,
                 "near_clip_meters": 0.1,
@@ -114,6 +116,8 @@ def test_convert_scenario_to_continuous_runtime_spec():
     assert spec.robot_start.rotation_y_degrees == 90.0
     assert spec.distance_sensor_range_meters == 7.5
     assert spec.camera.mount_height_meters == 0.7
+    assert spec.camera.mount_height_min_meters == 0.1
+    assert spec.camera.mount_height_max_meters == 1.0
     assert spec.camera.pitch_degrees == 5.0
     assert spec.camera.vertical_fov_degrees == 55.0
     assert spec.camera.near_clip_meters == 0.1
@@ -135,7 +139,7 @@ def test_convert_scenario_to_continuous_runtime_spec():
     assert spec.obstacles[1].rotation_y_degrees == 45.0
 
 
-def test_camera_far_clip_defaults_to_world_diagonal_when_unspecified():
+def test_camera_far_clip_uses_current_envforge_default_when_unspecified():
     scenario = ScenarioBundle(
         world={
             "bounds": {
@@ -152,7 +156,7 @@ def test_camera_far_clip_defaults_to_world_diagonal_when_unspecified():
     spec = convert_submission_to_spec(scenario)
 
     assert spec.distance_sensor_range_meters == 7.5
-    assert spec.camera.far_clip_meters == pytest.approx(((25.0**2) + (17.0**2)) ** 0.5)
+    assert spec.camera.far_clip_meters == pytest.approx(100.0)
 
 
 def test_parse_scenario_bundle_rejects_invalid_dict():


### PR DESCRIPTION
## Summary
- Render semantic camera observations from per-pixel camera projection
- Align camera defaults and height range handling with the scenario schema
- Keep runtime training models as resolved values instead of duplicate defaults

## Verification
- .venv/bin/ruff check .
- .venv/bin/pytest -q