### PR TITLE
fix: align robot radius contract

### DIFF
--- a/docs/implementation/data-models.md
+++ b/docs/implementation/data-models.md
@@ -92,7 +92,7 @@ request model: `embodiedlab.schemas.ScenarioBundle`
   },
   "compatibility": {
     "envforge_min_version": "0.1.0",
-    "robot_version": "simple_robot.v0",
+    "robot_version": "simple_robot.v1",
     "sensor_version": "basic_sensors.v0"
   },
   "world": {
@@ -111,6 +111,7 @@ request model: `embodiedlab.schemas.ScenarioBundle`
   },
   "robot": {
     "type": "simple_robot",
+    "radius": 0.45,
     "start_pose": {
       "position": { "x": 1.0, "z": 1.0 },
       "rotation_y_degrees": 0.0

--- a/embodiedlab/continuous_navigation_env.py
+++ b/embodiedlab/continuous_navigation_env.py
@@ -115,6 +115,7 @@ class ContinuousNavigationEnv(gym.Env):
         )
         self.robot_rotation_y_degrees = spec.robot_start.rotation_y_degrees
         self.steps = 0
+        self._robot_radius = float(spec.robot_radius)
         self._obstacle_ids = tuple(obstacle.obstacle_id for obstacle in spec.obstacles)
         self._obstacle_center_x = np.array(
             [obstacle.center_x for obstacle in spec.obstacles],
@@ -132,6 +133,8 @@ class ContinuousNavigationEnv(gym.Env):
             [obstacle.size_z / 2.0 for obstacle in spec.obstacles],
             dtype=np.float32,
         )
+        self._obstacle_collision_half_x = self._obstacle_half_x + self._robot_radius
+        self._obstacle_collision_half_z = self._obstacle_half_z + self._robot_radius
         self._obstacle_height = np.array(
             [obstacle.height for obstacle in spec.obstacles],
             dtype=np.float32,
@@ -191,8 +194,12 @@ class ContinuousNavigationEnv(gym.Env):
 
     def _inside_bounds(self, position: np.ndarray) -> bool:
         return bool(
-            self.spec.bounds.min_x <= position[0] <= self.spec.bounds.max_x
-            and self.spec.bounds.min_z <= position[1] <= self.spec.bounds.max_z,
+            self.spec.bounds.min_x + self._robot_radius
+            <= position[0]
+            <= self.spec.bounds.max_x - self._robot_radius
+            and self.spec.bounds.min_z + self._robot_radius
+            <= position[1]
+            <= self.spec.bounds.max_z - self._robot_radius,
         )
 
     def _collision_id(self, position: np.ndarray) -> str | None:
@@ -207,8 +214,8 @@ class ContinuousNavigationEnv(gym.Env):
         local_x = translated_x * self._obstacle_cos - translated_z * self._obstacle_sin
         local_z = translated_x * self._obstacle_sin + translated_z * self._obstacle_cos
         hits = np.nonzero(
-            (np.abs(local_x) <= self._obstacle_half_x)
-            & (np.abs(local_z) <= self._obstacle_half_z),
+            (np.abs(local_x) <= self._obstacle_collision_half_x)
+            & (np.abs(local_z) <= self._obstacle_collision_half_z),
         )[0]
         if len(hits) > 0:
             return self._obstacle_ids[int(hits[0])]
@@ -598,10 +605,10 @@ class ContinuousNavigationEnv(gym.Env):
         probe_z: np.ndarray,
     ) -> str | None:
         out_of_bounds = (
-            (probe_x < self.spec.bounds.min_x)
-            | (probe_x > self.spec.bounds.max_x)
-            | (probe_z < self.spec.bounds.min_z)
-            | (probe_z > self.spec.bounds.max_z)
+            (probe_x < self.spec.bounds.min_x + self._robot_radius)
+            | (probe_x > self.spec.bounds.max_x - self._robot_radius)
+            | (probe_z < self.spec.bounds.min_z + self._robot_radius)
+            | (probe_z > self.spec.bounds.max_z - self._robot_radius)
         )
         if len(self._obstacle_ids) == 0:
             return "world_bounds" if np.any(out_of_bounds) else None
@@ -610,8 +617,8 @@ class ContinuousNavigationEnv(gym.Env):
         translated_z = probe_z[:, None] - self._obstacle_center_z
         local_x = translated_x * self._obstacle_cos - translated_z * self._obstacle_sin
         local_z = translated_x * self._obstacle_sin + translated_z * self._obstacle_cos
-        obstacle_mask = (np.abs(local_x) <= self._obstacle_half_x) & (
-            np.abs(local_z) <= self._obstacle_half_z
+        obstacle_mask = (np.abs(local_x) <= self._obstacle_collision_half_x) & (
+            np.abs(local_z) <= self._obstacle_collision_half_z
         )
         for point_index in range(len(probe_x)):
             if out_of_bounds[point_index]:

--- a/embodiedlab/result_models.py
+++ b/embodiedlab/result_models.py
@@ -84,7 +84,7 @@ class ResultCompatibility(BaseModel):
 
     scenario_schema_version: str = Field(default="scenario-bundle.v0", min_length=1)
     envforge_min_version: str = Field(default="0.1.0", min_length=1)
-    robot_version: str = Field(default="simple_robot.v0", min_length=1)
+    robot_version: str = Field(default="simple_robot.v1", min_length=1)
     sensor_version: str = Field(default="basic_sensors.v0", min_length=1)
     action_layout: list[str] = Field(default_factory=lambda: ["forward", "turn"])
     observation_layout: list[str] = Field(

--- a/embodiedlab/schemas.py
+++ b/embodiedlab/schemas.py
@@ -9,6 +9,8 @@ from typing import Annotated, Literal
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 SCENARIO_SCHEMA_VERSION = "scenario-bundle.v0"
+ROBOT_VERSION = "simple_robot.v1"
+DEFAULT_ROBOT_RADIUS_METERS = 0.45
 
 
 class CoordinateSystem(StrEnum):
@@ -74,7 +76,7 @@ class Compatibility(BaseModel):
     """Compatibility metadata required by EnvForge and EmbodiedLab."""
 
     envforge_min_version: str = Field(default="0.1.0", min_length=1)
-    robot_version: str = Field(default="simple_robot.v0", min_length=1)
+    robot_version: str = Field(default=ROBOT_VERSION, min_length=1)
     sensor_version: str = Field(default="basic_sensors.v0", min_length=1)
 
 
@@ -214,6 +216,7 @@ class RobotSpec(BaseModel):
     """Robot descriptor for an EnvForge scenario."""
 
     type: RobotType = RobotType.SIMPLE_ROBOT
+    radius: float = Field(default=DEFAULT_ROBOT_RADIUS_METERS, gt=0)
     start_pose: Pose2D = Field(
         default_factory=lambda: Pose2D(
             position=Position2D(x=1.0, z=1.0),

--- a/embodiedlab/training/runner.py
+++ b/embodiedlab/training/runner.py
@@ -637,6 +637,7 @@ def run_continuous_navigation_training(  # noqa: PLR0913
                 "rotation_y_degrees": spec.robot_start.rotation_y_degrees,
             },
             "robot_type": spec.robot_type,
+            "robot_radius": spec.robot_radius,
             "success_rate": evaluation["success_rate"],
             "avg_reward": evaluation["avg_reward"],
             "avg_steps": evaluation["avg_steps"],

--- a/embodiedlab/training/training_converter.py
+++ b/embodiedlab/training/training_converter.py
@@ -198,6 +198,7 @@ def convert_submission_to_spec(
             rotation_y_degrees=start_pose.rotation_y_degrees,
         ),
         robot_type=scenario.robot.type.value,
+        robot_radius=scenario.robot.radius,
         distance_sensor_range_meters=distance_sensor_range_meters,
         camera=_camera_spec(scenario),
         reward_weights=_reward_weights(scenario),

--- a/embodiedlab/training/training_models.py
+++ b/embodiedlab/training/training_models.py
@@ -85,6 +85,7 @@ class ContinuousNavigationSpec:
     goal: ContinuousGoal
     robot_start: ContinuousRobotStart
     robot_type: str
+    robot_radius: float
     distance_sensor_range_meters: float
     camera: ContinuousCameraSpec
     reward_weights: ContinuousRewardWeights

--- a/tests/fixtures/envforge/navigation_default_scenario_bundle.json
+++ b/tests/fixtures/envforge/navigation_default_scenario_bundle.json
@@ -7,7 +7,7 @@
   },
   "compatibility": {
     "envforge_min_version": "0.1.0",
-    "robot_version": "simple_robot.v0",
+    "robot_version": "simple_robot.v1",
     "sensor_version": "basic_sensors.v0"
   },
   "world": {
@@ -137,6 +137,7 @@
   },
   "robot": {
     "type": "simple_robot",
+    "radius": 0.45,
     "start_pose": {
       "position": {
         "x": -6.0,

--- a/tests/test_continuous_navigation_env.py
+++ b/tests/test_continuous_navigation_env.py
@@ -314,6 +314,42 @@ def test_continuous_env_blocks_rotated_obstacle_collision():
     assert reward < -1.0
 
 
+def test_robot_radius_expands_movement_collision_but_not_sensor_geometry():
+    scenario = ScenarioBundle(
+        robot={
+            "radius": 0.45,
+            "start_pose": {
+                "position": {"x": 1.0, "z": 1.0},
+                "rotation_y_degrees": 0.0,
+            },
+        },
+        world={
+            "static_obstacles": [
+                {
+                    "id": "wall_001",
+                    "shape": "box",
+                    "center": {"x": 1.0, "z": 1.7},
+                    "size": {"x": 1.0, "z": 0.2},
+                },
+            ],
+        },
+        sensors=[
+            {"id": "front_camera", "type": "forward_camera"},
+            {"id": "front_distance", "type": "distance_sensor", "range_meters": 3.0},
+        ],
+    )
+    env = ContinuousNavigationEnv(
+        spec=convert_submission_to_spec(scenario),
+        max_steps=10,
+    )
+    _obs, info = env.reset()
+
+    assert info["front_distance"] == pytest.approx(0.605, abs=0.01)
+    assert (
+        env._collision_id(np.array([1.0, 1.2], dtype=np.float32)) == "wall_001"  # noqa: SLF001
+    )
+
+
 def test_continuous_env_blocks_thin_obstacle_between_movement_endpoints():
     scenario = ScenarioBundle(
         world={

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -22,7 +22,9 @@ def test_scenario_bundle_defaults_are_valid():
     assert scenario.scenario_id == "scenario_demo_001"
     assert scenario.world.coordinate_system == "envforge_xz_meters"
     assert scenario.world.goal.position.x == 8.5
+    assert scenario.compatibility.robot_version == "simple_robot.v1"
     assert scenario.robot.type == "simple_robot"
+    assert scenario.robot.radius == 0.45
     assert scenario.robot.action_space.layout == ["forward", "turn"]
     assert [sensor.id for sensor in scenario.sensors] == [
         "front_camera",
@@ -41,7 +43,9 @@ def test_build_submission_document_returns_firestore_payload():
     assert isinstance(payload["created_at"], str)
     assert payload["scenario"]["schema_version"] == "scenario-bundle.v0"
     assert payload["scenario"]["scenario_id"] == "scenario_demo_001"
+    assert payload["scenario"]["compatibility"]["robot_version"] == "simple_robot.v1"
     assert payload["scenario"]["robot"]["type"] == "simple_robot"
+    assert payload["scenario"]["robot"]["radius"] == 0.45
     assert payload["scenario"]["training"]["algorithm"] == "ppo"
 
 
@@ -70,6 +74,7 @@ def test_scenario_bundle_accepts_documented_shape():
                 },
             },
             "robot": {
+                "radius": 0.3,
                 "start_pose": {
                     "position": {"x": 1.0, "z": 1.0},
                     "rotation_y_degrees": 0.0,
@@ -120,6 +125,7 @@ def test_scenario_bundle_accepts_documented_shape():
 
     assert scenario.scenario_id == "scenario_custom"
     assert scenario.world.static_obstacles[0].id == "box_001"
+    assert scenario.robot.radius == 0.3
     assert scenario.sensors[0].width == 112
     assert scenario.sensors[0].height == 84
     assert scenario.sensors[0].mount_height_meters == 0.6

--- a/tests/test_training_converter.py
+++ b/tests/test_training_converter.py
@@ -63,6 +63,7 @@ def test_convert_scenario_to_continuous_runtime_spec():
             },
         },
         robot={
+            "radius": 0.3,
             "start_pose": {
                 "position": {"x": 1.9, "z": 2.1},
                 "rotation_y_degrees": 90.0,
@@ -113,6 +114,7 @@ def test_convert_scenario_to_continuous_runtime_spec():
     assert spec.goal.goal_id == "goal_001"
     assert spec.goal.radius == 0.75
     assert spec.robot_start.x == 1.9
+    assert spec.robot_radius == 0.3
     assert spec.robot_start.rotation_y_degrees == 90.0
     assert spec.distance_sensor_range_meters == 7.5
     assert spec.camera.mount_height_meters == 0.7


### PR DESCRIPTION
## Summary
- Add robot.radius/simple_robot.v1 to the Scenario Bundle schema and result compatibility metadata.
- Carry robot_radius into ContinuousNavigationSpec and inflate movement collision geometry by that radius.
- Keep sensor/camera geometry uninflated and add regression coverage for the split.

## Verification
- uv run ruff check embodiedlab server trainer tests notification
- uv run pytest
- make deploy_api
- make deploy_trainer