### PR TITLE
test: freeze Unity SDK wire contract fixtures

### DIFF
--- a/docs/implementation/unity-sdk-roadmap.md
+++ b/docs/implementation/unity-sdk-roadmap.md
@@ -89,6 +89,11 @@ Issue 本文に記載する。Codex は実装、test、lint、review、文書追
 2. SDK の最小公開 API と contract versioning。
 3. EnvForge 移行後の操作と end-to-end 結果。
 
+## 進行状況
+
+- Issue #24 で、SDK が読む completed Result Document と Replay Bundle manifest の
+  canonical fixture を追加し、現行 wire format を test で固定した。
+
 ## 保留事項
 
 - SDK repository の公開範囲、release、tag、package distribution の運用。

--- a/tests/fixtures/envforge/navigation_completed_result_document.json
+++ b/tests/fixtures/envforge/navigation_completed_result_document.json
@@ -1,0 +1,132 @@
+{
+  "submission_id": "submission-1",
+  "status": "completed",
+  "progress": {
+    "phase": "completed",
+    "current_step": 5000,
+    "total_steps": 5000,
+    "message": "Training completed"
+  },
+  "summary": {
+    "training_timesteps": 5000,
+    "training_seed": 10,
+    "success_rate": 0.82,
+    "avg_reward": 6.4,
+    "avg_steps": 118.5
+  },
+  "error": null,
+  "artifacts": {
+    "model": {
+      "storage": "gcs",
+      "bucket": "embodiedlab-models",
+      "path": "results/submission-1/model/policy.zip"
+    },
+    "onnx_model": {
+      "storage": "gcs",
+      "bucket": "embodiedlab-models",
+      "path": "results/submission-1/model/policy.onnx"
+    },
+    "sentis_model": {
+      "storage": "gcs",
+      "bucket": "embodiedlab-models",
+      "path": "results/submission-1/model/policy.sentis.onnx",
+      "format": "onnx",
+      "target": "unity-sentis",
+      "opset_version": 15,
+      "input": {
+        "name": "observation",
+        "shape": [1, 28226],
+        "dtype": "float32",
+        "layout": [
+          "obs_0_chw_3x84x112",
+          "obs_1_angle_degrees",
+          "obs_1_distance_meters"
+        ]
+      },
+      "output": {
+        "name": "action",
+        "layout": ["forward", "turn"],
+        "action_mapping": {
+          "forward": "sigmoid(policy_forward)",
+          "turn": "clip(policy_turn, -3, 3) / 3"
+        }
+      }
+    },
+    "replay_bundle": {
+      "storage": "gcs",
+      "bucket": "embodiedlab-models",
+      "path": "results/submission-1/replay/manifest.json",
+      "format": "json",
+      "schema_version": "replay-bundle.v0"
+    }
+  },
+  "result_bundle": {
+    "schema_version": "result-bundle.v0",
+    "scenario_id": "navigation_default",
+    "job_id": "submission-1",
+    "status": "completed",
+    "compatibility": {
+      "scenario_schema_version": "scenario-bundle.v0",
+      "envforge_min_version": "0.1.0",
+      "robot_version": "simple_robot.v1",
+      "sensor_version": "basic_sensors.v0",
+      "action_layout": ["forward", "turn"],
+      "observation_layout": ["front_camera", "front_distance"]
+    },
+    "summary": {
+      "training_timesteps": 5000,
+      "training_seed": 10,
+      "success_rate": 0.82,
+      "average_episode_reward": 6.4,
+      "average_episode_steps": 118.5
+    },
+    "artifacts": {
+      "model": {
+        "storage": "gcs",
+        "bucket": "embodiedlab-models",
+        "path": "results/submission-1/model/policy.onnx",
+        "format": "onnx"
+      },
+      "onnx_model": {
+        "storage": "gcs",
+        "bucket": "embodiedlab-models",
+        "path": "results/submission-1/model/policy.onnx",
+        "format": "onnx"
+      },
+      "sentis_model": {
+        "storage": "gcs",
+        "bucket": "embodiedlab-models",
+        "path": "results/submission-1/model/policy.sentis.onnx",
+        "format": "onnx",
+        "target": "unity-sentis",
+        "opset_version": 15,
+        "input": {
+          "name": "observation",
+          "shape": [1, 28226],
+          "dtype": "float32",
+          "layout": [
+            "obs_0_chw_3x84x112",
+            "obs_1_angle_degrees",
+            "obs_1_distance_meters"
+          ]
+        },
+        "output": {
+          "name": "action",
+          "layout": ["forward", "turn"],
+          "action_mapping": {
+            "forward": "sigmoid(policy_forward)",
+            "turn": "clip(policy_turn, -3, 3) / 3"
+          }
+        }
+      },
+      "replay_bundle": {
+        "storage": "gcs",
+        "bucket": "embodiedlab-models",
+        "path": "results/submission-1/replay/manifest.json",
+        "format": "json"
+      }
+    },
+    "error": null
+  },
+  "updated_at": "2026-07-13T00:00:00+00:00"
+}

--- a/tests/fixtures/envforge/navigation_replay_bundle_manifest.json
+++ b/tests/fixtures/envforge/navigation_replay_bundle_manifest.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": "replay-bundle.v0",
+  "job_id": "submission-1",
+  "scenario_id": "navigation_default",
+  "total_timesteps": 5000,
+  "chunks": [
+    {
+      "phase": "train",
+      "policy_mode": "stochastic",
+      "checkpoint_step": 2,
+      "start_step": 1,
+      "end_step": 2,
+      "path": "train/chunk_000000.jsonl.gz",
+      "format": "jsonl.gz",
+      "step_count": 2
+    },
+    {
+      "phase": "eval",
+      "policy_mode": "deterministic",
+      "checkpoint_step": 5000,
+      "path": "eval/checkpoint_00005000.jsonl.gz",
+      "format": "jsonl.gz",
+      "step_count": 2,
+      "episode_count": 1,
+      "success_rate": 1.0,
+      "avg_reward": 82.4,
+      "avg_steps": 118.5
+    }
+  ]
+}

--- a/tests/test_replay_bundle.py
+++ b/tests/test_replay_bundle.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+
+from embodiedlab.training.replay_bundle import ReplayBundleWriter
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def test_replay_bundle_writer_matches_canonical_manifest(tmp_path):
+    writer = ReplayBundleWriter(
+        root_dir=tmp_path / "replay",
+        job_id="submission-1",
+        scenario_id="navigation_default",
+        total_timesteps=5000,
+        train_chunk_steps=2,
+    )
+    writer.record_train_step({"checkpoint_step": 1})
+    writer.record_train_step({"checkpoint_step": 2})
+    writer.write_eval_checkpoint(
+        checkpoint_step=5000,
+        steps=[
+            {"episode_id": "eval_env_00_episode_000001", "step_index": 0},
+            {"episode_id": "eval_env_00_episode_000001", "step_index": 1},
+        ],
+        success_rate=1.0,
+        avg_reward=82.4,
+        avg_steps=118.5,
+    )
+
+    manifest = writer.finish()
+    fixture_path = (
+        FIXTURE_DIR / "envforge" / "navigation_replay_bundle_manifest.json"
+    )
+    expected = json.loads(fixture_path.read_text(encoding="utf-8"))
+    written = json.loads(
+        (writer.root_dir / "manifest.json").read_text(encoding="utf-8"),
+    )
+
+    assert manifest == expected
+    assert written == expected

--- a/tests/test_result_models.py
+++ b/tests/test_result_models.py
@@ -11,6 +11,7 @@ from embodiedlab.result_models import (
     ResultArtifacts,
     ResultBundle,
     ResultCompatibility,
+    ResultDocument,
     ResultStatus,
     TrainingSummary,
     build_queued_result_document,
@@ -151,6 +152,21 @@ def test_result_bundle_serializes_envforge_artifacts():
     assert payload["artifacts"]["sentis_model"]["target"] == "unity-sentis"
     assert payload["artifacts"]["sentis_model"]["input"]["shape"] == [1, 7]
     assert payload["artifacts"]["replay_bundle"]["format"] == "json"
+
+
+def test_completed_result_document_fixture_matches_contract():
+    fixture_path = (
+        FIXTURE_DIR / "envforge" / "navigation_completed_result_document.json"
+    )
+    payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+
+    document = ResultDocument.model_validate(payload)
+    result_bundle = ResultBundle.model_validate(document.result_bundle)
+
+    assert document.model_dump(mode="json") == payload
+    assert result_bundle.model_dump(mode="json") == payload["result_bundle"]
+    assert result_bundle.artifacts.model is not None
+    assert result_bundle.artifacts.replay_bundle is not None
 
 
 def test_replay_log_step_serializes_jsonl_row():


### PR DESCRIPTION
Closes #24

## Summary

- add a canonical completed Result Document fixture for Unity clients
- add a canonical Replay Bundle manifest fixture
- validate the completed document and nested Result Bundle against current models
- verify `ReplayBundleWriter` emits the canonical manifest shape
- record the completed baseline step in the Unity SDK roadmap

## Scope

This PR changes fixtures, tests, and documentation only. It does not change production API behavior or design the Unity SDK public API.

## Verification

- `uv run pytest` — 89 passed
- `uv run ruff check embodiedlab server trainer tests notification`
- `uv run pymarkdown scan --recurse --respect-gitignore README.md AGENTS.md docs`
- `git diff --check`