### PR TITLE
feat: publish versioned Unity SDK contract schemas

### DIFF
--- a/contracts/v0/replay-bundle-manifest.schema.json
+++ b/contracts/v0/replay-bundle-manifest.schema.json
@@ -1,0 +1,172 @@
+{
+  "$defs": {
+    "ReplayBundleChunk": {
+      "description": "One compressed train or evaluation chunk in a Replay Bundle.",
+      "properties": {
+        "avg_reward": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Avg Reward"
+        },
+        "avg_steps": {
+          "anyOf": [
+            {
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Avg Steps"
+        },
+        "checkpoint_step": {
+          "minimum": 0,
+          "title": "Checkpoint Step",
+          "type": "integer"
+        },
+        "end_step": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "End Step"
+        },
+        "episode_count": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Episode Count"
+        },
+        "format": {
+          "const": "jsonl.gz",
+          "title": "Format",
+          "type": "string"
+        },
+        "path": {
+          "minLength": 1,
+          "title": "Path",
+          "type": "string"
+        },
+        "phase": {
+          "enum": [
+            "train",
+            "eval"
+          ],
+          "title": "Phase",
+          "type": "string"
+        },
+        "policy_mode": {
+          "enum": [
+            "stochastic",
+            "deterministic"
+          ],
+          "title": "Policy Mode",
+          "type": "string"
+        },
+        "start_step": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Start Step"
+        },
+        "step_count": {
+          "minimum": 0,
+          "title": "Step Count",
+          "type": "integer"
+        },
+        "success_rate": {
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Success Rate"
+        }
+      },
+      "required": [
+        "phase",
+        "policy_mode",
+        "checkpoint_step",
+        "path",
+        "format",
+        "step_count"
+      ],
+      "title": "ReplayBundleChunk",
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Manifest describing the chunks in one Replay Bundle.",
+  "properties": {
+    "chunks": {
+      "items": {
+        "$ref": "#/$defs/ReplayBundleChunk"
+      },
+      "title": "Chunks",
+      "type": "array"
+    },
+    "job_id": {
+      "minLength": 1,
+      "title": "Job Id",
+      "type": "string"
+    },
+    "scenario_id": {
+      "minLength": 1,
+      "title": "Scenario Id",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "replay-bundle.v0",
+      "default": "replay-bundle.v0",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "total_timesteps": {
+      "minimum": 0,
+      "title": "Total Timesteps",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "job_id",
+    "scenario_id",
+    "total_timesteps"
+  ],
+  "title": "ReplayBundleManifest",
+  "type": "object"
+}

--- a/contracts/v0/replay-log-step.schema.json
+++ b/contracts/v0/replay-log-step.schema.json
@@ -1,0 +1,271 @@
+{
+  "$defs": {
+    "ReplayAction": {
+      "description": "Action values emitted for a replay step.",
+      "properties": {
+        "values": {
+          "items": {
+            "$ref": "#/$defs/ReplayNamedValue"
+          },
+          "title": "Values",
+          "type": "array"
+        }
+      },
+      "title": "ReplayAction",
+      "type": "object"
+    },
+    "ReplayEvent": {
+      "description": "A compact event emitted during replay.",
+      "properties": {
+        "message": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Message"
+        },
+        "object_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Object Id"
+        },
+        "type": {
+          "minLength": 1,
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "ReplayEvent",
+      "type": "object"
+    },
+    "ReplayNamedValue": {
+      "description": "A named scalar value in a JsonUtility-friendly replay payload.",
+      "properties": {
+        "name": {
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "value": {
+          "title": "Value",
+          "type": "number"
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ],
+      "title": "ReplayNamedValue",
+      "type": "object"
+    },
+    "ReplayPosition": {
+      "description": "A continuous replay position on the x/z plane.",
+      "properties": {
+        "x": {
+          "title": "X",
+          "type": "number"
+        },
+        "z": {
+          "title": "Z",
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "z"
+      ],
+      "title": "ReplayPosition",
+      "type": "object"
+    },
+    "ReplayReward": {
+      "description": "Reward values emitted for a replay step.",
+      "properties": {
+        "components": {
+          "items": {
+            "$ref": "#/$defs/ReplayNamedValue"
+          },
+          "title": "Components",
+          "type": "array"
+        },
+        "total": {
+          "title": "Total",
+          "type": "number"
+        }
+      },
+      "required": [
+        "total"
+      ],
+      "title": "ReplayReward",
+      "type": "object"
+    },
+    "ReplayRobotState": {
+      "description": "Robot state emitted in a replay step.",
+      "properties": {
+        "position": {
+          "$ref": "#/$defs/ReplayPosition"
+        },
+        "rotation_y_degrees": {
+          "title": "Rotation Y Degrees",
+          "type": "number"
+        }
+      },
+      "required": [
+        "position",
+        "rotation_y_degrees"
+      ],
+      "title": "ReplayRobotState",
+      "type": "object"
+    },
+    "ReplaySensorSummary": {
+      "description": "A compact sensor summary emitted during replay.",
+      "properties": {
+        "id": {
+          "minLength": 1,
+          "title": "Id",
+          "type": "string"
+        },
+        "type": {
+          "minLength": 1,
+          "title": "Type",
+          "type": "string"
+        },
+        "value": {
+          "title": "Value",
+          "type": "number"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "value"
+      ],
+      "title": "ReplaySensorSummary",
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "One JSON Lines row in an EnvForge replay log.",
+  "properties": {
+    "action": {
+      "$ref": "#/$defs/ReplayAction"
+    },
+    "checkpoint_step": {
+      "minimum": 0,
+      "title": "Checkpoint Step",
+      "type": "integer"
+    },
+    "env_index": {
+      "minimum": 0,
+      "title": "Env Index",
+      "type": "integer"
+    },
+    "episode_id": {
+      "minLength": 1,
+      "title": "Episode Id",
+      "type": "string"
+    },
+    "events": {
+      "items": {
+        "$ref": "#/$defs/ReplayEvent"
+      },
+      "title": "Events",
+      "type": "array"
+    },
+    "job_id": {
+      "minLength": 1,
+      "title": "Job Id",
+      "type": "string"
+    },
+    "phase": {
+      "minLength": 1,
+      "title": "Phase",
+      "type": "string"
+    },
+    "policy_mode": {
+      "minLength": 1,
+      "title": "Policy Mode",
+      "type": "string"
+    },
+    "reward": {
+      "$ref": "#/$defs/ReplayReward"
+    },
+    "robot": {
+      "$ref": "#/$defs/ReplayRobotState"
+    },
+    "scenario_id": {
+      "minLength": 1,
+      "title": "Scenario Id",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "replay-log.v0",
+      "default": "replay-log.v0",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "sensors": {
+      "items": {
+        "$ref": "#/$defs/ReplaySensorSummary"
+      },
+      "title": "Sensors",
+      "type": "array"
+    },
+    "step_index": {
+      "minimum": 0,
+      "title": "Step Index",
+      "type": "integer"
+    },
+    "terminated": {
+      "default": false,
+      "title": "Terminated",
+      "type": "boolean"
+    },
+    "termination_reason": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Termination Reason"
+    },
+    "time_seconds": {
+      "minimum": 0.0,
+      "title": "Time Seconds",
+      "type": "number"
+    }
+  },
+  "required": [
+    "scenario_id",
+    "job_id",
+    "phase",
+    "checkpoint_step",
+    "env_index",
+    "policy_mode",
+    "episode_id",
+    "step_index",
+    "time_seconds",
+    "robot",
+    "reward"
+  ],
+  "title": "ReplayLogStep",
+  "type": "object"
+}

--- a/contracts/v0/result-bundle.schema.json
+++ b/contracts/v0/result-bundle.schema.json
@@ -1,0 +1,453 @@
+{
+  "$defs": {
+    "ArtifactFormat": {
+      "description": "Supported artifact formats.",
+      "enum": [
+        "onnx",
+        "json",
+        "jsonl",
+        "jsonl.gz",
+        "zip"
+      ],
+      "title": "ArtifactFormat",
+      "type": "string"
+    },
+    "ArtifactLocation": {
+      "description": "Location and format of a result artifact.",
+      "properties": {
+        "bucket": {
+          "minLength": 1,
+          "title": "Bucket",
+          "type": "string"
+        },
+        "format": {
+          "$ref": "#/$defs/ArtifactFormat"
+        },
+        "path": {
+          "minLength": 1,
+          "title": "Path",
+          "type": "string"
+        },
+        "storage": {
+          "$ref": "#/$defs/ArtifactStorage",
+          "default": "gcs"
+        }
+      },
+      "required": [
+        "bucket",
+        "path",
+        "format"
+      ],
+      "title": "ArtifactLocation",
+      "type": "object"
+    },
+    "ArtifactStorage": {
+      "description": "Supported artifact storage backends.",
+      "enum": [
+        "gcs"
+      ],
+      "title": "ArtifactStorage",
+      "type": "string"
+    },
+    "ErrorReport": {
+      "description": "Structured failure details for failed result bundles.",
+      "properties": {
+        "details": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Details"
+        },
+        "message": {
+          "minLength": 1,
+          "title": "Message",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message"
+      ],
+      "title": "ErrorReport",
+      "type": "object"
+    },
+    "ModelArtifactLocation": {
+      "description": "Model artifact location with Unity compatibility metadata.",
+      "properties": {
+        "bucket": {
+          "minLength": 1,
+          "title": "Bucket",
+          "type": "string"
+        },
+        "format": {
+          "$ref": "#/$defs/ArtifactFormat"
+        },
+        "input": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ModelInput"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "opset_version": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Opset Version"
+        },
+        "output": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ModelOutput"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "path": {
+          "minLength": 1,
+          "title": "Path",
+          "type": "string"
+        },
+        "storage": {
+          "$ref": "#/$defs/ArtifactStorage",
+          "default": "gcs"
+        },
+        "target": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Target"
+        }
+      },
+      "required": [
+        "bucket",
+        "path",
+        "format"
+      ],
+      "title": "ModelArtifactLocation",
+      "type": "object"
+    },
+    "ModelInput": {
+      "description": "Input metadata for an EnvForge-loadable model artifact.",
+      "properties": {
+        "dtype": {
+          "minLength": 1,
+          "title": "Dtype",
+          "type": "string"
+        },
+        "layout": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Layout",
+          "type": "array"
+        },
+        "name": {
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "shape": {
+          "items": {
+            "type": "integer"
+          },
+          "title": "Shape",
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "dtype"
+      ],
+      "title": "ModelInput",
+      "type": "object"
+    },
+    "ModelOutput": {
+      "description": "Output metadata for an EnvForge-loadable model artifact.",
+      "properties": {
+        "action_mapping": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Action Mapping"
+        },
+        "layout": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Layout",
+          "type": "array"
+        },
+        "name": {
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "ModelOutput",
+      "type": "object"
+    },
+    "ResultArtifacts": {
+      "description": "Artifacts produced by a training run.",
+      "properties": {
+        "model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ArtifactLocation"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "onnx_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ArtifactLocation"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "replay_bundle": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ArtifactLocation"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "sentis_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ModelArtifactLocation"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "title": "ResultArtifacts",
+      "type": "object"
+    },
+    "ResultCompatibility": {
+      "description": "Compatibility metadata needed by EnvForge when loading a result.",
+      "properties": {
+        "action_layout": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Action Layout",
+          "type": "array"
+        },
+        "envforge_min_version": {
+          "default": "0.1.0",
+          "minLength": 1,
+          "title": "Envforge Min Version",
+          "type": "string"
+        },
+        "observation_layout": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Observation Layout",
+          "type": "array"
+        },
+        "robot_version": {
+          "default": "simple_robot.v1",
+          "minLength": 1,
+          "title": "Robot Version",
+          "type": "string"
+        },
+        "scenario_schema_version": {
+          "default": "scenario-bundle.v0",
+          "minLength": 1,
+          "title": "Scenario Schema Version",
+          "type": "string"
+        },
+        "sensor_version": {
+          "default": "basic_sensors.v0",
+          "minLength": 1,
+          "title": "Sensor Version",
+          "type": "string"
+        }
+      },
+      "title": "ResultCompatibility",
+      "type": "object"
+    },
+    "ResultStatus": {
+      "description": "Lifecycle states of a training result.",
+      "enum": [
+        "queued",
+        "starting",
+        "running",
+        "completed",
+        "failed"
+      ],
+      "title": "ResultStatus",
+      "type": "string"
+    },
+    "TrainingSummary": {
+      "description": "High-level metrics from a completed training run.",
+      "properties": {
+        "average_episode_reward": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Average Episode Reward"
+        },
+        "average_episode_steps": {
+          "anyOf": [
+            {
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Average Episode Steps"
+        },
+        "success_rate": {
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Success Rate"
+        },
+        "training_seed": {
+          "title": "Training Seed",
+          "type": "integer"
+        },
+        "training_timesteps": {
+          "minimum": 0,
+          "title": "Training Timesteps",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "training_timesteps",
+        "training_seed"
+      ],
+      "title": "TrainingSummary",
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "description": "EnvForge-facing training result bundle.",
+  "properties": {
+    "artifacts": {
+      "$ref": "#/$defs/ResultArtifacts"
+    },
+    "compatibility": {
+      "$ref": "#/$defs/ResultCompatibility"
+    },
+    "error": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ErrorReport"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "job_id": {
+      "minLength": 1,
+      "title": "Job Id",
+      "type": "string"
+    },
+    "scenario_id": {
+      "minLength": 1,
+      "title": "Scenario Id",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "result-bundle.v0",
+      "default": "result-bundle.v0",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "status": {
+      "$ref": "#/$defs/ResultStatus"
+    },
+    "summary": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TrainingSummary"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    }
+  },
+  "required": [
+    "scenario_id",
+    "job_id",
+    "status"
+  ],
+  "title": "ResultBundle",
+  "type": "object"
+}

--- a/contracts/v0/result-document.schema.json
+++ b/contracts/v0/result-document.schema.json
@@ -1,0 +1,567 @@
+{
+  "$defs": {
+    "ArtifactFormat": {
+      "description": "Supported artifact formats.",
+      "enum": [
+        "onnx",
+        "json",
+        "jsonl",
+        "jsonl.gz",
+        "zip"
+      ],
+      "title": "ArtifactFormat",
+      "type": "string"
+    },
+    "ArtifactLocation": {
+      "description": "Location and format of a result artifact.",
+      "properties": {
+        "bucket": {
+          "minLength": 1,
+          "title": "Bucket",
+          "type": "string"
+        },
+        "format": {
+          "$ref": "#/$defs/ArtifactFormat"
+        },
+        "path": {
+          "minLength": 1,
+          "title": "Path",
+          "type": "string"
+        },
+        "storage": {
+          "$ref": "#/$defs/ArtifactStorage",
+          "default": "gcs"
+        }
+      },
+      "required": [
+        "bucket",
+        "path",
+        "format"
+      ],
+      "title": "ArtifactLocation",
+      "type": "object"
+    },
+    "ArtifactStorage": {
+      "description": "Supported artifact storage backends.",
+      "enum": [
+        "gcs"
+      ],
+      "title": "ArtifactStorage",
+      "type": "string"
+    },
+    "ErrorReport": {
+      "description": "Structured failure details for failed result bundles.",
+      "properties": {
+        "details": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Details"
+        },
+        "message": {
+          "minLength": 1,
+          "title": "Message",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message"
+      ],
+      "title": "ErrorReport",
+      "type": "object"
+    },
+    "ModelArtifactLocation": {
+      "description": "Model artifact location with Unity compatibility metadata.",
+      "properties": {
+        "bucket": {
+          "minLength": 1,
+          "title": "Bucket",
+          "type": "string"
+        },
+        "format": {
+          "$ref": "#/$defs/ArtifactFormat"
+        },
+        "input": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ModelInput"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "opset_version": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Opset Version"
+        },
+        "output": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ModelOutput"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "path": {
+          "minLength": 1,
+          "title": "Path",
+          "type": "string"
+        },
+        "storage": {
+          "$ref": "#/$defs/ArtifactStorage",
+          "default": "gcs"
+        },
+        "target": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Target"
+        }
+      },
+      "required": [
+        "bucket",
+        "path",
+        "format"
+      ],
+      "title": "ModelArtifactLocation",
+      "type": "object"
+    },
+    "ModelInput": {
+      "description": "Input metadata for an EnvForge-loadable model artifact.",
+      "properties": {
+        "dtype": {
+          "minLength": 1,
+          "title": "Dtype",
+          "type": "string"
+        },
+        "layout": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Layout",
+          "type": "array"
+        },
+        "name": {
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "shape": {
+          "items": {
+            "type": "integer"
+          },
+          "title": "Shape",
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "dtype"
+      ],
+      "title": "ModelInput",
+      "type": "object"
+    },
+    "ModelOutput": {
+      "description": "Output metadata for an EnvForge-loadable model artifact.",
+      "properties": {
+        "action_mapping": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Action Mapping"
+        },
+        "layout": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Layout",
+          "type": "array"
+        },
+        "name": {
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "ModelOutput",
+      "type": "object"
+    },
+    "Progress": {
+      "description": "Training progress snapshot stored in each result document.",
+      "properties": {
+        "current_step": {
+          "minimum": 0,
+          "title": "Current Step",
+          "type": "integer"
+        },
+        "message": {
+          "title": "Message",
+          "type": "string"
+        },
+        "phase": {
+          "$ref": "#/$defs/ResultStatus"
+        },
+        "total_steps": {
+          "minimum": 0,
+          "title": "Total Steps",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "phase",
+        "current_step",
+        "total_steps",
+        "message"
+      ],
+      "title": "Progress",
+      "type": "object"
+    },
+    "ResultArtifacts": {
+      "description": "Artifacts produced by a training run.",
+      "properties": {
+        "model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ArtifactLocation"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "onnx_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ArtifactLocation"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "replay_bundle": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ArtifactLocation"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "sentis_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ModelArtifactLocation"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "title": "ResultArtifacts",
+      "type": "object"
+    },
+    "ResultBundle": {
+      "additionalProperties": true,
+      "description": "EnvForge-facing training result bundle.",
+      "properties": {
+        "artifacts": {
+          "$ref": "#/$defs/ResultArtifacts"
+        },
+        "compatibility": {
+          "$ref": "#/$defs/ResultCompatibility"
+        },
+        "error": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ErrorReport"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "job_id": {
+          "minLength": 1,
+          "title": "Job Id",
+          "type": "string"
+        },
+        "scenario_id": {
+          "minLength": 1,
+          "title": "Scenario Id",
+          "type": "string"
+        },
+        "schema_version": {
+          "const": "result-bundle.v0",
+          "default": "result-bundle.v0",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/$defs/ResultStatus"
+        },
+        "summary": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TrainingSummary"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "scenario_id",
+        "job_id",
+        "status"
+      ],
+      "title": "ResultBundle",
+      "type": "object"
+    },
+    "ResultCompatibility": {
+      "description": "Compatibility metadata needed by EnvForge when loading a result.",
+      "properties": {
+        "action_layout": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Action Layout",
+          "type": "array"
+        },
+        "envforge_min_version": {
+          "default": "0.1.0",
+          "minLength": 1,
+          "title": "Envforge Min Version",
+          "type": "string"
+        },
+        "observation_layout": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Observation Layout",
+          "type": "array"
+        },
+        "robot_version": {
+          "default": "simple_robot.v1",
+          "minLength": 1,
+          "title": "Robot Version",
+          "type": "string"
+        },
+        "scenario_schema_version": {
+          "default": "scenario-bundle.v0",
+          "minLength": 1,
+          "title": "Scenario Schema Version",
+          "type": "string"
+        },
+        "sensor_version": {
+          "default": "basic_sensors.v0",
+          "minLength": 1,
+          "title": "Sensor Version",
+          "type": "string"
+        }
+      },
+      "title": "ResultCompatibility",
+      "type": "object"
+    },
+    "ResultStatus": {
+      "description": "Lifecycle states of a training result.",
+      "enum": [
+        "queued",
+        "starting",
+        "running",
+        "completed",
+        "failed"
+      ],
+      "title": "ResultStatus",
+      "type": "string"
+    },
+    "TrainingSummary": {
+      "description": "High-level metrics from a completed training run.",
+      "properties": {
+        "average_episode_reward": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Average Episode Reward"
+        },
+        "average_episode_steps": {
+          "anyOf": [
+            {
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Average Episode Steps"
+        },
+        "success_rate": {
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Success Rate"
+        },
+        "training_seed": {
+          "title": "Training Seed",
+          "type": "integer"
+        },
+        "training_timesteps": {
+          "minimum": 0,
+          "title": "Training Timesteps",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "training_timesteps",
+        "training_seed"
+      ],
+      "title": "TrainingSummary",
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "description": "Full result document written to Firestore.",
+  "properties": {
+    "artifacts": {
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Artifacts"
+    },
+    "error": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Error"
+    },
+    "progress": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Progress"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "result_bundle": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ResultBundle"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "status": {
+      "$ref": "#/$defs/ResultStatus"
+    },
+    "submission_id": {
+      "minLength": 1,
+      "title": "Submission Id",
+      "type": "string"
+    },
+    "summary": {
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Summary"
+    },
+    "updated_at": {
+      "title": "Updated At",
+      "type": "string"
+    }
+  },
+  "required": [
+    "submission_id",
+    "status"
+  ],
+  "title": "ResultDocument",
+  "type": "object"
+}

--- a/contracts/v0/scenario-bundle.schema.json
+++ b/contracts/v0/scenario-bundle.schema.json
@@ -1,0 +1,780 @@
+{
+  "$defs": {
+    "ActionSpace": {
+      "description": "Robot action layout expected by the policy.",
+      "properties": {
+        "layout": {
+          "items": {
+            "enum": [
+              "forward",
+              "turn"
+            ],
+            "type": "string"
+          },
+          "maxItems": 2,
+          "minItems": 2,
+          "title": "Layout",
+          "type": "array"
+        },
+        "type": {
+          "$ref": "#/$defs/ActionSpaceType",
+          "default": "continuous"
+        }
+      },
+      "title": "ActionSpace",
+      "type": "object"
+    },
+    "ActionSpaceType": {
+      "description": "Supported robot action space families.",
+      "enum": [
+        "continuous"
+      ],
+      "title": "ActionSpaceType",
+      "type": "string"
+    },
+    "Bounds2D": {
+      "description": "Axis-aligned world bounds on the x/z plane.",
+      "properties": {
+        "max": {
+          "$ref": "#/$defs/Position2D"
+        },
+        "min": {
+          "$ref": "#/$defs/Position2D"
+        }
+      },
+      "required": [
+        "min",
+        "max"
+      ],
+      "title": "Bounds2D",
+      "type": "object"
+    },
+    "CollisionRewardComponent": {
+      "description": "Reward component emitted on collisions.",
+      "properties": {
+        "name": {
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "type": {
+          "const": "collision",
+          "default": "collision",
+          "title": "Type",
+          "type": "string"
+        },
+        "weight": {
+          "title": "Weight",
+          "type": "number"
+        }
+      },
+      "required": [
+        "name",
+        "weight"
+      ],
+      "title": "CollisionRewardComponent",
+      "type": "object"
+    },
+    "Compatibility": {
+      "description": "Compatibility metadata required by EnvForge and EmbodiedLab.",
+      "properties": {
+        "envforge_min_version": {
+          "default": "0.1.0",
+          "minLength": 1,
+          "title": "Envforge Min Version",
+          "type": "string"
+        },
+        "robot_version": {
+          "default": "simple_robot.v1",
+          "minLength": 1,
+          "title": "Robot Version",
+          "type": "string"
+        },
+        "sensor_version": {
+          "default": "basic_sensors.v0",
+          "minLength": 1,
+          "title": "Sensor Version",
+          "type": "string"
+        }
+      },
+      "title": "Compatibility",
+      "type": "object"
+    },
+    "CoordinateSystem": {
+      "description": "Supported world coordinate systems for scenario bundles.",
+      "enum": [
+        "envforge_xz_meters"
+      ],
+      "title": "CoordinateSystem",
+      "type": "string"
+    },
+    "CreatedBy": {
+      "description": "Metadata about the tool that created a scenario bundle.",
+      "properties": {
+        "tool": {
+          "default": "EnvForge",
+          "minLength": 1,
+          "title": "Tool",
+          "type": "string"
+        },
+        "version": {
+          "default": "0.1.0",
+          "minLength": 1,
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "title": "CreatedBy",
+      "type": "object"
+    },
+    "DistanceDeltaRewardComponent": {
+      "description": "Reward based on distance progress toward a target object.",
+      "properties": {
+        "name": {
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "target": {
+          "minLength": 1,
+          "title": "Target",
+          "type": "string"
+        },
+        "type": {
+          "const": "distance_delta",
+          "default": "distance_delta",
+          "title": "Type",
+          "type": "string"
+        },
+        "weight": {
+          "title": "Weight",
+          "type": "number"
+        }
+      },
+      "required": [
+        "name",
+        "target",
+        "weight"
+      ],
+      "title": "DistanceDeltaRewardComponent",
+      "type": "object"
+    },
+    "DistanceSensor": {
+      "description": "Forward distance sensor configuration.",
+      "properties": {
+        "direction": {
+          "$ref": "#/$defs/SensorDirection",
+          "default": "forward"
+        },
+        "id": {
+          "minLength": 1,
+          "title": "Id",
+          "type": "string"
+        },
+        "range_meters": {
+          "default": 5.0,
+          "exclusiveMinimum": 0,
+          "title": "Range Meters",
+          "type": "number"
+        },
+        "type": {
+          "const": "distance_sensor",
+          "default": "distance_sensor",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "DistanceSensor",
+      "type": "object"
+    },
+    "ForwardCameraSensor": {
+      "description": "Forward semantic camera sensor configuration.",
+      "properties": {
+        "far_clip_meters": {
+          "default": 100.0,
+          "exclusiveMinimum": 0,
+          "title": "Far Clip Meters",
+          "type": "number"
+        },
+        "height": {
+          "default": 84,
+          "minimum": 1,
+          "title": "Height",
+          "type": "integer"
+        },
+        "id": {
+          "minLength": 1,
+          "title": "Id",
+          "type": "string"
+        },
+        "mount_height_max_meters": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Mount Height Max Meters"
+        },
+        "mount_height_meters": {
+          "default": 0.6,
+          "exclusiveMinimum": 0,
+          "title": "Mount Height Meters",
+          "type": "number"
+        },
+        "mount_height_min_meters": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Mount Height Min Meters"
+        },
+        "near_clip_meters": {
+          "default": 0.05,
+          "exclusiveMinimum": 0,
+          "title": "Near Clip Meters",
+          "type": "number"
+        },
+        "pitch_degrees": {
+          "default": 0.0,
+          "title": "Pitch Degrees",
+          "type": "number"
+        },
+        "semantic_mode": {
+          "$ref": "#/$defs/SemanticMode",
+          "default": "traversable_vs_blocked"
+        },
+        "type": {
+          "const": "forward_camera",
+          "default": "forward_camera",
+          "title": "Type",
+          "type": "string"
+        },
+        "vertical_fov_degrees": {
+          "default": 70.0,
+          "exclusiveMaximum": 180,
+          "exclusiveMinimum": 0,
+          "title": "Vertical Fov Degrees",
+          "type": "number"
+        },
+        "width": {
+          "default": 112,
+          "minimum": 1,
+          "title": "Width",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "ForwardCameraSensor",
+      "type": "object"
+    },
+    "GoalSpec": {
+      "description": "Goal region used for navigation training.",
+      "properties": {
+        "id": {
+          "minLength": 1,
+          "title": "Id",
+          "type": "string"
+        },
+        "position": {
+          "$ref": "#/$defs/Position2D"
+        },
+        "radius": {
+          "exclusiveMinimum": 0,
+          "title": "Radius",
+          "type": "number"
+        }
+      },
+      "required": [
+        "id",
+        "position",
+        "radius"
+      ],
+      "title": "GoalSpec",
+      "type": "object"
+    },
+    "PerStepRewardComponent": {
+      "description": "Reward component emitted at each simulation step.",
+      "properties": {
+        "name": {
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "type": {
+          "const": "per_step",
+          "default": "per_step",
+          "title": "Type",
+          "type": "string"
+        },
+        "weight": {
+          "title": "Weight",
+          "type": "number"
+        }
+      },
+      "required": [
+        "name",
+        "weight"
+      ],
+      "title": "PerStepRewardComponent",
+      "type": "object"
+    },
+    "Pose2D": {
+      "description": "Robot pose on the x/z plane.",
+      "properties": {
+        "position": {
+          "$ref": "#/$defs/Position2D"
+        },
+        "rotation_y_degrees": {
+          "default": 0.0,
+          "title": "Rotation Y Degrees",
+          "type": "number"
+        }
+      },
+      "required": [
+        "position"
+      ],
+      "title": "Pose2D",
+      "type": "object"
+    },
+    "Position2D": {
+      "description": "A point on the EnvForge horizontal x/z plane.",
+      "properties": {
+        "x": {
+          "title": "X",
+          "type": "number"
+        },
+        "z": {
+          "title": "Z",
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "z"
+      ],
+      "title": "Position2D",
+      "type": "object"
+    },
+    "RewardSpec": {
+      "description": "Declarative reward configuration for training.",
+      "properties": {
+        "components": {
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "collision": "#/$defs/CollisionRewardComponent",
+                "distance_delta": "#/$defs/DistanceDeltaRewardComponent",
+                "per_step": "#/$defs/PerStepRewardComponent",
+                "terminal_reward": "#/$defs/TerminalRewardComponent"
+              },
+              "propertyName": "type"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/TerminalRewardComponent"
+              },
+              {
+                "$ref": "#/$defs/DistanceDeltaRewardComponent"
+              },
+              {
+                "$ref": "#/$defs/CollisionRewardComponent"
+              },
+              {
+                "$ref": "#/$defs/PerStepRewardComponent"
+              }
+            ]
+          },
+          "title": "Components",
+          "type": "array"
+        }
+      },
+      "title": "RewardSpec",
+      "type": "object"
+    },
+    "RobotSpec": {
+      "description": "Robot descriptor for an EnvForge scenario.",
+      "properties": {
+        "action_space": {
+          "$ref": "#/$defs/ActionSpace"
+        },
+        "radius": {
+          "default": 0.45,
+          "exclusiveMinimum": 0,
+          "title": "Radius",
+          "type": "number"
+        },
+        "start_pose": {
+          "$ref": "#/$defs/Pose2D"
+        },
+        "type": {
+          "$ref": "#/$defs/RobotType",
+          "default": "simple_robot"
+        }
+      },
+      "title": "RobotSpec",
+      "type": "object"
+    },
+    "RobotType": {
+      "description": "Robot archetypes supported by the first EnvForge integration.",
+      "enum": [
+        "simple_robot"
+      ],
+      "title": "RobotType",
+      "type": "string"
+    },
+    "SemanticMode": {
+      "description": "Supported semantic camera encodings.",
+      "enum": [
+        "traversable_vs_blocked"
+      ],
+      "title": "SemanticMode",
+      "type": "string"
+    },
+    "SensorDirection": {
+      "description": "Supported distance sensor directions.",
+      "enum": [
+        "forward"
+      ],
+      "title": "SensorDirection",
+      "type": "string"
+    },
+    "Size2D": {
+      "description": "A positive x/z footprint size in meters.",
+      "properties": {
+        "x": {
+          "exclusiveMinimum": 0,
+          "title": "X",
+          "type": "number"
+        },
+        "z": {
+          "exclusiveMinimum": 0,
+          "title": "Z",
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "z"
+      ],
+      "title": "Size2D",
+      "type": "object"
+    },
+    "StaticObstacle": {
+      "description": "A fixed obstacle in the scenario.",
+      "properties": {
+        "center": {
+          "$ref": "#/$defs/Position2D"
+        },
+        "height": {
+          "default": 1.0,
+          "exclusiveMinimum": 0,
+          "title": "Height",
+          "type": "number"
+        },
+        "id": {
+          "minLength": 1,
+          "title": "Id",
+          "type": "string"
+        },
+        "rotation_y_degrees": {
+          "default": 0.0,
+          "title": "Rotation Y Degrees",
+          "type": "number"
+        },
+        "shape": {
+          "const": "box",
+          "default": "box",
+          "title": "Shape",
+          "type": "string"
+        },
+        "size": {
+          "$ref": "#/$defs/Size2D"
+        }
+      },
+      "required": [
+        "id",
+        "center",
+        "size"
+      ],
+      "title": "StaticObstacle",
+      "type": "object"
+    },
+    "StaticWall": {
+      "description": "A fixed wall segment in the scenario.",
+      "properties": {
+        "center": {
+          "$ref": "#/$defs/Position2D"
+        },
+        "height": {
+          "default": 2.0,
+          "exclusiveMinimum": 0,
+          "title": "Height",
+          "type": "number"
+        },
+        "id": {
+          "minLength": 1,
+          "title": "Id",
+          "type": "string"
+        },
+        "rotation_y_degrees": {
+          "default": 0.0,
+          "title": "Rotation Y Degrees",
+          "type": "number"
+        },
+        "size": {
+          "$ref": "#/$defs/Size2D"
+        }
+      },
+      "required": [
+        "id",
+        "center",
+        "size"
+      ],
+      "title": "StaticWall",
+      "type": "object"
+    },
+    "TerminalRewardComponent": {
+      "description": "Terminal reward paid when the task succeeds.",
+      "properties": {
+        "name": {
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "type": {
+          "const": "terminal_reward",
+          "default": "terminal_reward",
+          "title": "Type",
+          "type": "string"
+        },
+        "weight": {
+          "title": "Weight",
+          "type": "number"
+        }
+      },
+      "required": [
+        "name",
+        "weight"
+      ],
+      "title": "TerminalRewardComponent",
+      "type": "object"
+    },
+    "TrainingAlgorithm": {
+      "description": "Supported training algorithms for EnvForge scenarios.",
+      "enum": [
+        "ppo"
+      ],
+      "title": "TrainingAlgorithm",
+      "type": "string"
+    },
+    "TrainingSpec": {
+      "description": "Training request parameters for EnvForge scenario bundles.",
+      "properties": {
+        "algorithm": {
+          "$ref": "#/$defs/TrainingAlgorithm",
+          "default": "ppo"
+        },
+        "batch_size": {
+          "default": 32,
+          "minimum": 1,
+          "title": "Batch Size",
+          "type": "integer"
+        },
+        "cpu_count": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Cpu Count"
+        },
+        "ent_coef": {
+          "default": 0.0,
+          "minimum": 0.0,
+          "title": "Ent Coef",
+          "type": "number"
+        },
+        "eval_episodes": {
+          "default": 20,
+          "minimum": 1,
+          "title": "Eval Episodes",
+          "type": "integer"
+        },
+        "gamma": {
+          "default": 0.99,
+          "exclusiveMinimum": 0.0,
+          "maximum": 1.0,
+          "title": "Gamma",
+          "type": "number"
+        },
+        "learning_rate": {
+          "default": 0.0003,
+          "exclusiveMinimum": 0.0,
+          "title": "Learning Rate",
+          "type": "number"
+        },
+        "max_episode_steps": {
+          "default": 512,
+          "minimum": 1,
+          "title": "Max Episode Steps",
+          "type": "integer"
+        },
+        "n_envs": {
+          "default": 1,
+          "minimum": 1,
+          "title": "N Envs",
+          "type": "integer"
+        },
+        "n_epochs": {
+          "default": 3,
+          "minimum": 1,
+          "title": "N Epochs",
+          "type": "integer"
+        },
+        "n_steps": {
+          "default": 32,
+          "minimum": 1,
+          "title": "N Steps",
+          "type": "integer"
+        },
+        "seed": {
+          "default": 10,
+          "title": "Seed",
+          "type": "integer"
+        },
+        "timesteps": {
+          "default": 5000,
+          "minimum": 1,
+          "title": "Timesteps",
+          "type": "integer"
+        },
+        "torch_num_threads": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Torch Num Threads"
+        }
+      },
+      "title": "TrainingSpec",
+      "type": "object"
+    },
+    "WorldSpec": {
+      "description": "Static world geometry for the first EnvForge contract.",
+      "properties": {
+        "bounds": {
+          "$ref": "#/$defs/Bounds2D"
+        },
+        "coordinate_system": {
+          "$ref": "#/$defs/CoordinateSystem",
+          "default": "envforge_xz_meters"
+        },
+        "goal": {
+          "$ref": "#/$defs/GoalSpec"
+        },
+        "static_obstacles": {
+          "items": {
+            "$ref": "#/$defs/StaticObstacle"
+          },
+          "title": "Static Obstacles",
+          "type": "array"
+        },
+        "static_walls": {
+          "items": {
+            "$ref": "#/$defs/StaticWall"
+          },
+          "title": "Static Walls",
+          "type": "array"
+        }
+      },
+      "title": "WorldSpec",
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Top-level request body for POST /submissions.",
+  "properties": {
+    "compatibility": {
+      "$ref": "#/$defs/Compatibility"
+    },
+    "created_by": {
+      "$ref": "#/$defs/CreatedBy"
+    },
+    "reward": {
+      "$ref": "#/$defs/RewardSpec"
+    },
+    "robot": {
+      "$ref": "#/$defs/RobotSpec"
+    },
+    "scenario_id": {
+      "default": "scenario_demo_001",
+      "minLength": 1,
+      "title": "Scenario Id",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "scenario-bundle.v0",
+      "default": "scenario-bundle.v0",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "sensors": {
+      "items": {
+        "discriminator": {
+          "mapping": {
+            "distance_sensor": "#/$defs/DistanceSensor",
+            "forward_camera": "#/$defs/ForwardCameraSensor"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/$defs/ForwardCameraSensor"
+          },
+          {
+            "$ref": "#/$defs/DistanceSensor"
+          }
+        ]
+      },
+      "minItems": 1,
+      "title": "Sensors",
+      "type": "array"
+    },
+    "training": {
+      "$ref": "#/$defs/TrainingSpec"
+    },
+    "world": {
+      "$ref": "#/$defs/WorldSpec"
+    }
+  },
+  "title": "ScenarioBundle",
+  "type": "object"
+}

--- a/contracts/v0/submission-response.schema.json
+++ b/contracts/v0/submission-response.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Response returned after accepting a submission or training request.",
+  "properties": {
+    "status": {
+      "const": "accepted",
+      "title": "Status",
+      "type": "string"
+    },
+    "submission_id": {
+      "minLength": 1,
+      "title": "Submission Id",
+      "type": "string"
+    }
+  },
+  "required": [
+    "status",
+    "submission_id"
+  ],
+  "title": "SubmissionResponse",
+  "type": "object"
+}

--- a/docs/implementation/unity-sdk-roadmap.md
+++ b/docs/implementation/unity-sdk-roadmap.md
@@ -66,6 +66,21 @@ seed、制約を表現できる最小範囲から設計する。選択結果は 
 
 ユーザ提供の C# や Python の任意コード実行は、このロードマップの対象外とする。
 
+## Contract 生成方針
+
+EmbodiedLab の Pydantic model を wire contract の正本とし、versioned JSON Schema を
+`contracts/v0` へ決定的に出力する。Scenario Bundle、Result Document、Result Bundle、
+Replay Bundle、Replay Log と API response を対象とする。
+
+`EmbodiedLab.Unity` はこの JSON Schema から C# DTO を生成する。生成済み DTO は
+UPM package に含め、package 利用者に generator の実行を要求しない。通信と job lifecycle
+を扱う公開 API は手書きとし、生成された REST client をそのまま公開 API にしない。
+canonical fixture は code generation 後も cross-repository の適合 test として維持する。
+contract の再生成と差分検査には次を使う。
+
+    uv run python -m tools.export_contract_schemas
+    uv run python -m tools.export_contract_schemas --check
+
 ## 実装順序
 
 1. EmbodiedLab API と現在の EnvForge client の動作を fixture と test で固定する。
@@ -93,11 +108,13 @@ Issue 本文に記載する。Codex は実装、test、lint、review、文書追
 
 - Issue #24 で、SDK が読む completed Result Document と Replay Bundle manifest の
   canonical fixture を追加し、現行 wire format を test で固定した。
+- Issue #26 で、現行 API response と Replay Bundle を Pydantic model に結び付け、
+  Unity DTO 生成元となる versioned JSON Schema の公開に着手した。
 
 ## 保留事項
 
 - SDK repository の公開範囲、release、tag、package distribution の運用。
-- JSON Schema / OpenAPI から Unity DTO を生成するか、fixture 適合 test を正本とするか。
+- C# DTO generator の固定方法と、生成差分を SDK 側で検証する CI。
 - 認証導入後の token storage と signed artifact URL。
 - job cancellation、quota、cost control。
 - `generated` mode の最初の schema と、生成結果を Replay のどこへ記録するか。

--- a/embodiedlab/api_models.py
+++ b/embodiedlab/api_models.py
@@ -1,0 +1,12 @@
+"""Wire models shared by EmbodiedLab API clients and services."""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class SubmissionResponse(BaseModel):
+    """Response returned after accepting a submission or training request."""
+
+    status: Literal["accepted"]
+    submission_id: str = Field(min_length=1)

--- a/embodiedlab/result_models.py
+++ b/embodiedlab/result_models.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -124,7 +124,9 @@ class ErrorReport(BaseModel):
 class ResultBundle(BaseModel):
     """EnvForge-facing training result bundle."""
 
-    schema_version: str = RESULT_SCHEMA_VERSION
+    model_config = ConfigDict(extra="allow")
+
+    schema_version: Literal[RESULT_SCHEMA_VERSION] = RESULT_SCHEMA_VERSION
     scenario_id: str = Field(min_length=1)
     job_id: str = Field(min_length=1)
     status: ResultStatus
@@ -187,7 +189,7 @@ class ReplaySensorSummary(BaseModel):
 class ReplayLogStep(BaseModel):
     """One JSON Lines row in an EnvForge replay log."""
 
-    schema_version: str = REPLAY_LOG_SCHEMA_VERSION
+    schema_version: Literal[REPLAY_LOG_SCHEMA_VERSION] = REPLAY_LOG_SCHEMA_VERSION
     scenario_id: str = Field(min_length=1)
     job_id: str = Field(min_length=1)
     phase: str = Field(min_length=1)
@@ -204,6 +206,33 @@ class ReplayLogStep(BaseModel):
     sensors: list[ReplaySensorSummary] = Field(default_factory=list)
     terminated: bool = False
     termination_reason: str | None = None
+
+
+class ReplayBundleChunk(BaseModel):
+    """One compressed train or evaluation chunk in a Replay Bundle."""
+
+    phase: Literal["train", "eval"]
+    policy_mode: Literal["stochastic", "deterministic"]
+    checkpoint_step: int = Field(ge=0)
+    start_step: int | None = Field(default=None, ge=0)
+    end_step: int | None = Field(default=None, ge=0)
+    path: str = Field(min_length=1)
+    format: Literal["jsonl.gz"]
+    step_count: int = Field(ge=0)
+    episode_count: int | None = Field(default=None, ge=0)
+    success_rate: float | None = Field(default=None, ge=0.0, le=1.0)
+    avg_reward: float | None = None
+    avg_steps: float | None = Field(default=None, ge=0.0)
+
+
+class ReplayBundleManifest(BaseModel):
+    """Manifest describing the chunks in one Replay Bundle."""
+
+    schema_version: Literal[REPLAY_BUNDLE_SCHEMA_VERSION] = REPLAY_BUNDLE_SCHEMA_VERSION
+    job_id: str = Field(min_length=1)
+    scenario_id: str = Field(min_length=1)
+    total_timesteps: int = Field(ge=0)
+    chunks: list[ReplayBundleChunk] = Field(default_factory=list)
 
 
 def utc_now_iso() -> str:
@@ -223,13 +252,15 @@ class Progress(BaseModel):
 class ResultDocument(BaseModel):
     """Full result document written to Firestore."""
 
-    submission_id: str
+    model_config = ConfigDict(extra="allow")
+
+    submission_id: str = Field(min_length=1)
     status: ResultStatus
-    progress: Progress
+    progress: Progress | None = None
     summary: dict[str, Any] | None = None
     error: str | None = None
     artifacts: dict[str, Any] | None = None
-    result_bundle: dict[str, Any] | ResultBundle | None = None
+    result_bundle: ResultBundle | None = None
     updated_at: str = Field(default_factory=utc_now_iso)
 
 
@@ -242,7 +273,7 @@ class ResultMessage(BaseModel):
     summary: dict[str, Any] | None = None
     error: str | None = None
     artifacts: dict[str, Any] | None = None
-    result_bundle: dict[str, Any] | ResultBundle | None = None
+    result_bundle: ResultBundle | None = None
     updated_at: str = Field(default_factory=utc_now_iso)
 
 
@@ -254,7 +285,7 @@ class ResultUpdate(BaseModel):
     summary: dict[str, Any] | None = None
     error: str | None = None
     artifacts: dict[str, Any] | None = None
-    result_bundle: dict[str, Any] | ResultBundle | None = None
+    result_bundle: ResultBundle | None = None
     updated_at: str = Field(default_factory=utc_now_iso)
 
 

--- a/embodiedlab/training/replay_bundle.py
+++ b/embodiedlab/training/replay_bundle.py
@@ -7,6 +7,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from embodiedlab.result_models import ReplayBundleManifest
+
 DEFAULT_TRAIN_CHUNK_STEPS = 10_000
 
 
@@ -91,13 +93,12 @@ class ReplayBundleWriter:
     def finish(self) -> dict[str, Any]:
         """Close pending chunks and write the Replay Bundle manifest."""
         self._close_train_chunk()
-        manifest = {
-            "schema_version": "replay-bundle.v0",
-            "job_id": self.job_id,
-            "scenario_id": self.scenario_id,
-            "total_timesteps": self.total_timesteps,
-            "chunks": self._chunks,
-        }
+        manifest = ReplayBundleManifest(
+            job_id=self.job_id,
+            scenario_id=self.scenario_id,
+            total_timesteps=self.total_timesteps,
+            chunks=self._chunks,
+        ).model_dump(mode="json", exclude_none=True)
         (self.root_dir / "manifest.json").write_text(
             json.dumps(manifest, indent=2),
             encoding="utf-8",

--- a/server/routes.py
+++ b/server/routes.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Any
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
 
+from embodiedlab.api_models import SubmissionResponse
 from embodiedlab.repositories import (
     ResultFailureWriter,
     ResultQueueWriter,
@@ -13,6 +14,7 @@ from embodiedlab.repositories import (
     SubmissionExistenceChecker,
     SubmissionWriter,
 )
+from embodiedlab.result_models import ResultDocument
 from embodiedlab.schemas import ScenarioBundle
 from server.config import ServerConfig
 from server.dependencies import (
@@ -42,14 +44,11 @@ def create_submission(
         SubmissionWriter,
         Depends(get_submission_repository),
     ],
-) -> dict[str, str]:
+) -> SubmissionResponse:
     """Create a new submission and persist it to Firestore."""
     submission_id = submission_repository.save(scenario)
 
-    return {
-        "status": "accepted",
-        "submission_id": submission_id,
-    }
+    return SubmissionResponse(status="accepted", submission_id=submission_id)
 
 
 @router.post("/submissions/{submission_id}/train")
@@ -64,7 +63,7 @@ def train(
         ResultQueueWriter | ResultFailureWriter,
         Depends(get_result_repository),
     ],
-) -> dict[str, str]:
+) -> SubmissionResponse:
     """Queue a result document and trigger the trainer job."""
     try:
         start_training_for_submission(
@@ -82,13 +81,14 @@ def train(
             detail=exc.message,
         ) from exc
 
-    return {
-        "status": "accepted",
-        "submission_id": submission_id,
-    }
+    return SubmissionResponse(status="accepted", submission_id=submission_id)
 
 
-@router.get("/results/{submission_id}")
+@router.get(
+    "/results/{submission_id}",
+    response_model=ResultDocument,
+    response_model_exclude_unset=True,
+)
 def get_result(
     submission_id: str,
     server_config: Annotated[ServerConfig, Depends(get_config)],
@@ -100,16 +100,18 @@ def get_result(
         ExecutionFailureFinder,
         Depends(get_execution_failure_finder),
     ],
-) -> dict[str, Any]:
+) -> ResultDocument:
     """Return the latest result document for the submission."""
     result = result_repository.fetch(submission_id)
     if result is None:
         raise HTTPException(status_code=404, detail="Result not found")
 
-    return reconcile_result_with_execution_failure(
-        config=server_config,
-        submission_id=submission_id,
-        result_repository=result_repository,
-        result=result,
-        find_failed_execution=find_execution_failure,
+    return ResultDocument.model_validate(
+        reconcile_result_with_execution_failure(
+            config=server_config,
+            submission_id=submission_id,
+            result_repository=result_repository,
+            result=result,
+            find_failed_execution=find_execution_failure,
+        ),
     )

--- a/tests/test_contract_schemas.py
+++ b/tests/test_contract_schemas.py
@@ -1,0 +1,34 @@
+from server.main import create_app
+from tools.export_contract_schemas import (
+    CONTRACT_DIR,
+    render_contract_schemas,
+)
+
+
+def test_committed_contract_schemas_match_fresh_export():
+    expected = render_contract_schemas()
+    actual_names = {
+        path.name for path in CONTRACT_DIR.glob("*.schema.json") if path.is_file()
+    }
+
+    assert actual_names == set(expected)
+    for file_name, content in expected.items():
+        assert (CONTRACT_DIR / file_name).read_text(encoding="utf-8") == content
+
+
+def test_openapi_exposes_typed_sdk_responses():
+    openapi = create_app().openapi()
+
+    submission_response = openapi["paths"]["/submissions"]["post"]["responses"]["200"][
+        "content"
+    ]["application/json"]["schema"]
+    training_response = openapi["paths"]["/submissions/{submission_id}/train"]["post"][
+        "responses"
+    ]["200"]["content"]["application/json"]["schema"]
+    result_response = openapi["paths"]["/results/{submission_id}"]["get"]["responses"][
+        "200"
+    ]["content"]["application/json"]["schema"]
+
+    assert submission_response == {"$ref": "#/components/schemas/SubmissionResponse"}
+    assert training_response == {"$ref": "#/components/schemas/SubmissionResponse"}
+    assert result_response == {"$ref": "#/components/schemas/ResultDocument"}

--- a/tests/test_replay_bundle.py
+++ b/tests/test_replay_bundle.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+from embodiedlab.result_models import ReplayBundleManifest
 from embodiedlab.training.replay_bundle import ReplayBundleWriter
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"
@@ -28,13 +29,13 @@ def test_replay_bundle_writer_matches_canonical_manifest(tmp_path):
     )
 
     manifest = writer.finish()
-    fixture_path = (
-        FIXTURE_DIR / "envforge" / "navigation_replay_bundle_manifest.json"
-    )
+    fixture_path = FIXTURE_DIR / "envforge" / "navigation_replay_bundle_manifest.json"
     expected = json.loads(fixture_path.read_text(encoding="utf-8"))
     written = json.loads(
         (writer.root_dir / "manifest.json").read_text(encoding="utf-8"),
     )
+    validated = ReplayBundleManifest.model_validate(expected)
 
     assert manifest == expected
     assert written == expected
+    assert validated.model_dump(mode="json", exclude_none=True) == expected

--- a/tools/export_contract_schemas.py
+++ b/tools/export_contract_schemas.py
@@ -1,0 +1,96 @@
+"""Export deterministic JSON Schemas for Unity SDK contract generation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from embodiedlab.api_models import SubmissionResponse
+from embodiedlab.result_models import (
+    ReplayBundleManifest,
+    ReplayLogStep,
+    ResultBundle,
+    ResultDocument,
+)
+from embodiedlab.schemas import ScenarioBundle
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_DIR = PROJECT_ROOT / "contracts" / "v0"
+JSON_SCHEMA_DIALECT = "https://json-schema.org/draft/2020-12/schema"
+
+CONTRACT_MODELS: tuple[tuple[str, type[BaseModel]], ...] = (
+    ("scenario-bundle.schema.json", ScenarioBundle),
+    ("submission-response.schema.json", SubmissionResponse),
+    ("result-document.schema.json", ResultDocument),
+    ("result-bundle.schema.json", ResultBundle),
+    ("replay-bundle-manifest.schema.json", ReplayBundleManifest),
+    ("replay-log-step.schema.json", ReplayLogStep),
+)
+
+
+def render_contract_schemas() -> dict[str, str]:
+    """Return canonical JSON text for every published contract model."""
+    rendered = {}
+    for file_name, model_type in CONTRACT_MODELS:
+        schema = {
+            "$schema": JSON_SCHEMA_DIALECT,
+            **model_type.model_json_schema(mode="serialization"),
+        }
+        rendered[file_name] = (
+            json.dumps(schema, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+        )
+    return rendered
+
+
+def write_contract_schemas() -> None:
+    """Write all generated schemas to the versioned contract directory."""
+    CONTRACT_DIR.mkdir(parents=True, exist_ok=True)
+    for file_name, content in render_contract_schemas().items():
+        (CONTRACT_DIR / file_name).write_text(content, encoding="utf-8")
+
+
+def check_contract_schemas() -> bool:
+    """Return whether committed schema files match a fresh export."""
+    expected = render_contract_schemas()
+    actual_names = {
+        path.name for path in CONTRACT_DIR.glob("*.schema.json") if path.is_file()
+    }
+    expected_names = set(expected)
+    valid = actual_names == expected_names
+
+    for file_name, content in expected.items():
+        path = CONTRACT_DIR / file_name
+        if not path.is_file() or path.read_text(encoding="utf-8") != content:
+            print(f"Contract schema is out of date: {path.relative_to(PROJECT_ROOT)}")
+            valid = False
+
+    for file_name in sorted(actual_names - expected_names):
+        print(f"Unexpected contract schema: contracts/v0/{file_name}")
+
+    return valid
+
+
+def main() -> int:
+    """Run the contract exporter or drift check."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail when committed schemas differ from a fresh export.",
+    )
+    args = parser.parse_args()
+
+    if args.check:
+        return 0 if check_contract_schemas() else 1
+
+    write_contract_schemas()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #26

## Summary

- publish deterministic JSON Schemas for the current SDK-facing contracts under `contracts/v0`
- add typed submission responses and a typed FastAPI Result Document response without changing existing JSON payloads
- model and validate Replay Bundle manifests and chunks in the writer itself
- add schema drift and OpenAPI response tests
- record the agreed Pydantic-to-JSON-Schema contract workflow in the Unity SDK roadmap

## Contract behavior

- canonical EnvForge fixtures remain the behavior-preserving examples
- unknown top-level Result Document fields remain preserved
- incomplete legacy result snapshots still pass through without injected fields
- generated C# DTOs and the Unity Job API remain out of scope for this PR

## Verification

- `uv run pytest` — 91 passed
- `uv run ruff check embodiedlab server trainer tests notification tools`
- `uv run ruff format --check` on all changed Python files
- `uv run pymarkdown scan --recurse --respect-gitignore README.md AGENTS.md docs`
- `uv run python -m tools.export_contract_schemas --check`
- `git diff --check`
