### PR TITLE
refactor: remove top-level result artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,8 @@ Result documents include:
   `completed`, or `failed`
 - `progress`: phase, current step, total steps, and message
 - `summary`: training and evaluation summary when completed
-- `artifacts`: GCS model location when completed
+- `result_bundle`: typed summary, artifact locations, compatibility metadata,
+  and structured failure details
 - `error`: failure detail when failed
 
 ### Stream Result Updates

--- a/contracts/v0/result-document.schema.json
+++ b/contracts/v0/result-document.schema.json
@@ -487,19 +487,6 @@
   "additionalProperties": true,
   "description": "Full result document written to Firestore.",
   "properties": {
-    "artifacts": {
-      "anyOf": [
-        {
-          "additionalProperties": true,
-          "type": "object"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "title": "Artifacts"
-    },
     "error": {
       "anyOf": [
         {

--- a/docs/implementation/data-models.md
+++ b/docs/implementation/data-models.md
@@ -259,18 +259,44 @@ bootstrap では `roles/run.viewer` を付与する。キャンセルは project
     "training_seed": 10
   },
   "error": null,
-  "artifacts": {
-    "model": {
-      "storage": "gcs",
-      "bucket": "my-model-bucket",
-      "path": "models/submission-123/policy.zip"
+  "result_bundle": {
+    "schema_version": "result-bundle.v0",
+    "scenario_id": "scenario_demo_001",
+    "job_id": "submission-123",
+    "status": "completed",
+    "compatibility": {
+      "scenario_schema_version": "scenario-bundle.v0",
+      "envforge_min_version": "0.1.0",
+      "robot_version": "simple_robot.v1",
+      "sensor_version": "basic_sensors.v0",
+      "action_layout": ["forward", "turn"],
+      "observation_layout": ["front_camera", "front_distance"]
+    },
+    "summary": {
+      "training_timesteps": 5000,
+      "training_seed": 10,
+      "success_rate": 0.95,
+      "average_episode_reward": 6.4,
+      "average_episode_steps": 118.5
+    },
+    "artifacts": {
+      "model": {
+        "storage": "gcs",
+        "bucket": "my-model-bucket",
+        "path": "results/submission-123/model/policy.onnx",
+        "format": "onnx"
+      }
     }
   },
   "updated_at": "2026-04-24T12:34:56.000000+00:00"
 }
 ```
 
-artifact path は `models/{submission_id}/` 配下の GCS object path である。
+artifact metadata の正規の格納先は `result_bundle.artifacts` だけであり、
+Result Document の top-level には複製しない。旧 top-level artifact だけを持つ
+result は現行 Unity client の対象外とする。
+
+artifact path は `results/{submission_id}/` 配下の GCS object path である。
 現在の Makefile-created model bucket は public object read を許可する。
 これは prototype 用であり、今後 access control を見直す。
 
@@ -362,7 +388,7 @@ published shape: `embodiedlab.result_models.ResultMessage`
   },
   "summary": null,
   "error": null,
-  "artifacts": null,
+  "result_bundle": null,
   "updated_at": "2026-04-24T12:35:12.000000+00:00"
 }
 ```

--- a/docs/implementation/unity-sdk-roadmap.md
+++ b/docs/implementation/unity-sdk-roadmap.md
@@ -113,6 +113,9 @@ Issue 本文に記載する。Codex は実装、test、lint、review、文書追
 - Issue #28 で、合意した `T-B2 + C-B` の前提となる capability token 付き
   クラウドジョブキャンセル、正確な Cloud Run Execution name の保存、
   `cancelling` / `cancelled` 契約と WebSocket 通知を実装する。
+- Issue #30 で、Result Document と result event の旧 top-level `artifacts` を
+  削除し、`result_bundle.artifacts` を唯一の artifact contract とする。
+  旧形式への fallback や互換 API は追加しない。
 
 状態監視は WebSocket を通常経路とし、接続失敗、切断、無通信、明示更新時だけ
 HTTP の Result Document へ再同期する。正常な WebSocket 接続中に定期 HTTP polling は

--- a/embodiedlab/repositories.py
+++ b/embodiedlab/repositories.py
@@ -69,7 +69,6 @@ class ResultUpdateWriter(Protocol):
         progress: Progress,
         summary: dict[str, Any] | None = None,
         error: str | None = None,
-        artifacts: dict[str, Any] | None = None,
         result_bundle: dict[str, Any] | ResultBundle | None = None,
     ) -> None:
         """Persist a partial result update."""

--- a/embodiedlab/result_events.py
+++ b/embodiedlab/result_events.py
@@ -22,7 +22,6 @@ def publish_result_event(  # noqa: PLR0913
     progress: Progress,
     summary: dict[str, Any] | None = None,
     error: str | None = None,
-    artifacts: dict[str, Any] | None = None,
     result_bundle: dict[str, Any] | ResultBundle | None = None,
 ) -> None:
     """Publish one ordered result lifecycle event."""
@@ -32,7 +31,6 @@ def publish_result_event(  # noqa: PLR0913
         progress=progress,
         summary=summary,
         error=error,
-        artifacts=artifacts,
         result_bundle=result_bundle,
     )
     publisher = pubsub_v1.PublisherClient(

--- a/embodiedlab/result_models.py
+++ b/embodiedlab/result_models.py
@@ -261,7 +261,6 @@ class ResultDocument(BaseModel):
     progress: Progress | None = None
     summary: dict[str, Any] | None = None
     error: str | None = None
-    artifacts: dict[str, Any] | None = None
     result_bundle: ResultBundle | None = None
     updated_at: str = Field(default_factory=utc_now_iso)
 
@@ -274,7 +273,6 @@ class ResultMessage(BaseModel):
     progress: Progress | None = None
     summary: dict[str, Any] | None = None
     error: str | None = None
-    artifacts: dict[str, Any] | None = None
     result_bundle: ResultBundle | None = None
     updated_at: str = Field(default_factory=utc_now_iso)
 
@@ -286,7 +284,6 @@ class ResultUpdate(BaseModel):
     progress: Progress
     summary: dict[str, Any] | None = None
     error: str | None = None
-    artifacts: dict[str, Any] | None = None
     result_bundle: ResultBundle | None = None
     updated_at: str = Field(default_factory=utc_now_iso)
 
@@ -510,13 +507,12 @@ def build_queued_result_document(submission_id: str) -> dict:
     return document.model_dump(mode="json")
 
 
-def build_result_update(  # noqa: PLR0913
+def build_result_update(
     *,
     status: ResultStatus,
     progress: dict | Progress,
     summary: dict[str, Any] | None = None,
     error: str | None = None,
-    artifacts: dict[str, Any] | None = None,
     result_bundle: dict[str, Any] | ResultBundle | None = None,
 ) -> dict:
     """Return a Firestore-ready dict for a partial result update."""
@@ -525,7 +521,6 @@ def build_result_update(  # noqa: PLR0913
         progress=progress,
         summary=summary,
         error=error,
-        artifacts=artifacts,
         result_bundle=result_bundle,
     )
     return update.model_dump(mode="json")
@@ -537,7 +532,6 @@ def build_result_message(  # noqa: PLR0913
     progress: Progress,
     summary: dict[str, Any] | None = None,
     error: str | None = None,
-    artifacts: dict[str, Any] | None = None,
     result_bundle: dict[str, Any] | ResultBundle | None = None,
 ) -> dict:
     """Return a dict suitable for publishing as a Pub/Sub message."""
@@ -547,7 +541,6 @@ def build_result_message(  # noqa: PLR0913
         progress=progress,
         summary=summary,
         error=error,
-        artifacts=artifacts,
         result_bundle=result_bundle,
     )
     return message.model_dump(mode="json")

--- a/rules/coding-style.md
+++ b/rules/coding-style.md
@@ -9,10 +9,12 @@
   Firestore
 - `ResultStatus` is a `StrEnum` — values are lowercase strings used directly in
   Firestore documents
-- Result `artifacts` payloads are plain JSON dicts. GCS artifacts use
+- Uploaded artifact payloads are plain JSON dicts used to build
+  `ResultBundle.artifacts`. GCS artifacts use
   `{ "storage": "gcs", "bucket": "...", "path": "..." }`; completed training
   results should include `model` (`policy.zip`), `onnx_model` (`policy.onnx`),
-  and `sentis_model` (`policy.sentis.onnx`) when upload succeeds.
+  and `sentis_model` (`policy.sentis.onnx`) when upload succeeds. Result
+  documents and events do not duplicate these values at the top level.
 
 ## Markdown
 

--- a/server/repositories.py
+++ b/server/repositories.py
@@ -105,7 +105,6 @@ class FirestoreResultRepository(ResultQueueWriter, ResultReader, ResultUpdateWri
         progress: Progress,
         summary: dict[str, Any] | None = None,
         error: str | None = None,
-        artifacts: dict[str, Any] | None = None,
         result_bundle: dict[str, Any] | ResultBundle | None = None,
     ) -> None:
         """Merge a lifecycle update into a result document."""
@@ -114,7 +113,6 @@ class FirestoreResultRepository(ResultQueueWriter, ResultReader, ResultUpdateWri
             progress=progress,
             summary=summary,
             error=error,
-            artifacts=artifacts,
             result_bundle=result_bundle,
         )
         self._db.collection("results").document(submission_id).set(payload, merge=True)

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -147,7 +147,6 @@ class FakeResultRepository:
         progress,
         summary: dict | None = None,
         error: str | None = None,
-        artifacts: dict | None = None,
         result_bundle: dict | ResultBundle | None = None,
     ) -> None:
         payload = build_result_update(
@@ -155,7 +154,6 @@ class FakeResultRepository:
             progress=progress,
             summary=summary,
             error=error,
-            artifacts=artifacts,
             result_bundle=result_bundle,
         )
         existing = self.results.get(submission_id, {})

--- a/tests/fixtures/envforge/navigation_completed_result_document.json
+++ b/tests/fixtures/envforge/navigation_completed_result_document.json
@@ -15,51 +15,6 @@
     "avg_steps": 118.5
   },
   "error": null,
-  "artifacts": {
-    "model": {
-      "storage": "gcs",
-      "bucket": "embodiedlab-models",
-      "path": "results/submission-1/model/policy.zip"
-    },
-    "onnx_model": {
-      "storage": "gcs",
-      "bucket": "embodiedlab-models",
-      "path": "results/submission-1/model/policy.onnx"
-    },
-    "sentis_model": {
-      "storage": "gcs",
-      "bucket": "embodiedlab-models",
-      "path": "results/submission-1/model/policy.sentis.onnx",
-      "format": "onnx",
-      "target": "unity-sentis",
-      "opset_version": 15,
-      "input": {
-        "name": "observation",
-        "shape": [1, 28226],
-        "dtype": "float32",
-        "layout": [
-          "obs_0_chw_3x84x112",
-          "obs_1_angle_degrees",
-          "obs_1_distance_meters"
-        ]
-      },
-      "output": {
-        "name": "action",
-        "layout": ["forward", "turn"],
-        "action_mapping": {
-          "forward": "sigmoid(policy_forward)",
-          "turn": "clip(policy_turn, -3, 3) / 3"
-        }
-      }
-    },
-    "replay_bundle": {
-      "storage": "gcs",
-      "bucket": "embodiedlab-models",
-      "path": "results/submission-1/replay/manifest.json",
-      "format": "json",
-      "schema_version": "replay-bundle.v0"
-    }
-  },
   "result_bundle": {
     "schema_version": "result-bundle.v0",
     "scenario_id": "navigation_default",

--- a/tests/test_result_models.py
+++ b/tests/test_result_models.py
@@ -46,7 +46,7 @@ def test_build_queued_result_document_returns_firestore_payload():
     }
     assert payload["summary"] is None
     assert payload["error"] is None
-    assert payload["artifacts"] is None
+    assert "artifacts" not in payload
     assert isinstance(payload["updated_at"], str)
 
 
@@ -100,6 +100,7 @@ def test_parse_result_message_validates_and_normalizes_payload():
     assert parsed["submission_id"] == "submission-1"
     assert parsed["status"] == "running"
     assert parsed["progress"]["phase"] == "running"
+    assert "artifacts" not in parsed
 
 
 def test_result_bundle_serializes_envforge_artifacts():
@@ -173,6 +174,7 @@ def test_completed_result_document_fixture_matches_contract():
 
     assert document.model_dump(mode="json") == payload
     assert result_bundle.model_dump(mode="json") == payload["result_bundle"]
+    assert "artifacts" not in payload
     assert result_bundle.artifacts.model is not None
     assert result_bundle.artifacts.replay_bundle is not None
 

--- a/tests/test_server_app.py
+++ b/tests/test_server_app.py
@@ -566,7 +566,11 @@ def test_submission_train_and_result_flow_integrates_with_trainer(monkeypatch):
         "average_episode_reward": None,
         "average_episode_steps": None,
     }
-    assert result_response.json()["artifacts"]["model"]["bucket"] == "model-bucket"
+    assert "artifacts" not in result_response.json()
+    assert (
+        result_response.json()["result_bundle"]["artifacts"]["model"]["bucket"]
+        == "model-bucket"
+    )
     assert [event["status"].value for event in published_events] == [
         "starting",
         "running",

--- a/tests/test_trainer_job.py
+++ b/tests/test_trainer_job.py
@@ -95,19 +95,7 @@ def test_run_training_job_updates_result_to_completed():
         "training_timesteps": 5000,
         "training_seed": 10,
     }
-    assert payloads[-1]["data"]["artifacts"]["model"]["bucket"] == "model-bucket"
-    assert (
-        payloads[-1]["data"]["artifacts"]["onnx_model"]["path"]
-        == "results/submission-1/model/policy.onnx"
-    )
-    assert (
-        payloads[-1]["data"]["artifacts"]["sentis_model"]["path"]
-        == "results/submission-1/model/policy.sentis.onnx"
-    )
-    assert (
-        payloads[-1]["data"]["artifacts"]["replay_bundle"]["path"]
-        == "results/submission-1/replay/manifest.json"
-    )
+    assert "artifacts" not in payloads[-1]["data"]
     assert payloads[-1]["data"]["result_bundle"]["schema_version"] == (
         "result-bundle.v0"
     )

--- a/trainer/job.py
+++ b/trainer/job.py
@@ -146,7 +146,6 @@ def run_training_job(  # noqa: PLR0913
             status=ResultStatus.COMPLETED,
             progress=completed_progress(total_steps),
             summary=execution.summary,
-            artifacts=execution.artifacts,
             result_bundle=execution.result_bundle,
         )
 

--- a/trainer/pubsub.py
+++ b/trainer/pubsub.py
@@ -19,7 +19,6 @@ def publish_training_event(  # noqa: PLR0913
     progress: Progress,
     summary: dict[str, Any] | None = None,
     error: str | None = None,
-    artifacts: dict[str, Any] | None = None,
     result_bundle: dict[str, Any] | ResultBundle | None = None,
 ) -> None:
     """Publish a training status event to the configured Pub/Sub topic."""
@@ -31,6 +30,5 @@ def publish_training_event(  # noqa: PLR0913
         progress=progress,
         summary=summary,
         error=error,
-        artifacts=artifacts,
         result_bundle=result_bundle,
     )

--- a/trainer/repositories.py
+++ b/trainer/repositories.py
@@ -53,7 +53,6 @@ class FirestoreResultRepository(ResultUpdateWriter):
         progress: Progress,
         summary: dict[str, Any] | None = None,
         error: str | None = None,
-        artifacts: dict[str, Any] | None = None,
         result_bundle: dict[str, Any] | ResultBundle | None = None,
     ) -> None:
         """Merge a status/progress update into the result document."""
@@ -62,7 +61,6 @@ class FirestoreResultRepository(ResultUpdateWriter):
             progress=progress,
             summary=summary,
             error=error,
-            artifacts=artifacts,
             result_bundle=result_bundle,
         )
         self._db.collection("results").document(submission_id).set(payload, merge=True)

--- a/trainer/results.py
+++ b/trainer/results.py
@@ -22,7 +22,6 @@ def update_result(  # noqa: PLR0913
     progress: dict | Progress,
     summary: dict[str, Any] | None = None,
     error: str | None = None,
-    artifacts: dict[str, Any] | None = None,
     result_bundle: dict[str, Any] | ResultBundle | None = None,
 ) -> None:
     """Merge a status/progress update into the result document."""
@@ -31,7 +30,6 @@ def update_result(  # noqa: PLR0913
         progress=progress,
         summary=summary,
         error=error,
-        artifacts=artifacts,
         result_bundle=result_bundle,
     )
     result_ref.set(payload, merge=True)

--- a/trainer/training_service.py
+++ b/trainer/training_service.py
@@ -46,7 +46,6 @@ class TrainingExecution:
     """Outcome of a completed training run."""
 
     summary: dict[str, Any]
-    artifacts: dict[str, Any]
     result_bundle: ResultBundle
 
 
@@ -124,7 +123,5 @@ def execute_training_run(  # noqa: PLR0913
 
     return TrainingExecution(
         summary=summary,
-        artifacts=artifacts,
         result_bundle=result_bundle,
     )
-

--- a/trainer/transitions.py
+++ b/trainer/transitions.py
@@ -21,14 +21,13 @@ class TrainerResultTransitions:
     result_repository: ResultUpdateWriter
     publish_event: PublishEvent
 
-    def write(  # noqa: PLR0913
+    def write(
         self,
         *,
         status: ResultStatus,
         progress: Progress,
         summary: dict[str, Any] | None = None,
         error: str | None = None,
-        artifacts: dict[str, Any] | None = None,
         result_bundle: dict[str, Any] | ResultBundle | None = None,
     ) -> None:
         """Persist a result transition and publish the corresponding event."""
@@ -38,7 +37,6 @@ class TrainerResultTransitions:
             progress=progress,
             summary=summary,
             error=error,
-            artifacts=artifacts,
             result_bundle=result_bundle,
         )
         self.publish_event(
@@ -48,6 +46,5 @@ class TrainerResultTransitions:
             progress=progress,
             summary=summary,
             error=error,
-            artifacts=artifacts,
             result_bundle=result_bundle,
         )


### PR DESCRIPTION
## Summary

- remove the legacy top-level `artifacts` field from result documents and events
- keep `result_bundle.artifacts` as the only artifact location
- update the canonical schema, fixture, tests, and documentation
- intentionally provide no compatibility fallback for top-level-only result documents

## Validation

- `python3 -m compileall -q embodiedlab trainer server tests`
- `pytest tests/test_result_models.py` (10 passed)
- affected server/trainer suite in the connector workspace (29 passed, 1 unrelated route-registration test deselected because the partial workspace cannot use the repository lockfile)
- JSON Schema and canonical fixture assertions with `jq`
- `ruff format --check` for all changed Python files
- scoped `ruff check` for all changed Python files
- `markdownlint-cli2` for changed Markdown files

Closes #30